### PR TITLE
Network Configuration Module

### DIFF
--- a/src/client/stellarClient.ts
+++ b/src/client/stellarClient.ts
@@ -2,13 +2,16 @@ import {
   Account,
   FeeBumpTransaction,
   Keypair,
-  Networks,
   rpc,
   Transaction,
   TransactionBuilder
 } from "@stellar/stellar-sdk";
 
-import { AxionveraNetwork, resolveNetworkConfig } from "../utils/networkConfig";
+import {
+  AxionveraNetwork,
+  getNetworkPassphrase,
+  resolveNetworkConfig
+} from "../utils/networkConfig";
 import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG, createConcurrencyControlledClient } from "../utils/concurrencyQueue";
 import { RetryConfig, createHttpClientWithRetry, retry } from "../utils/httpInterceptor";
 
@@ -228,12 +231,7 @@ export class StellarClient {
    * @returns The corresponding network passphrase
    */
   static getDefaultNetworkPassphrase(network: AxionveraNetwork): string {
-    switch (network) {
-      case "testnet":
-        return Networks.TESTNET;
-      case "mainnet":
-        return Networks.PUBLIC;
-    }
+    return getNetworkPassphrase(network);
   }
 
   /**

--- a/tests/networkConfig.test.ts
+++ b/tests/networkConfig.test.ts
@@ -1,0 +1,48 @@
+import { Networks } from "@stellar/stellar-sdk";
+import {
+  getDefaultRpcUrl,
+  getNetworkPassphrase,
+  resolveNetworkConfig
+} from "../src/utils/networkConfig";
+
+describe("networkConfig", () => {
+  test("getNetworkPassphrase returns correct passphrases", () => {
+    expect(getNetworkPassphrase("testnet")).toBe(Networks.TESTNET);
+    expect(getNetworkPassphrase("mainnet")).toBe(Networks.PUBLIC);
+  });
+
+  test("getDefaultRpcUrl returns known RPC endpoints", () => {
+    expect(getDefaultRpcUrl("testnet")).toBe("https://soroban-testnet.stellar.org");
+    expect(getDefaultRpcUrl("mainnet")).toBe("https://soroban-mainnet.stellar.org");
+  });
+
+  test("resolveNetworkConfig uses defaults and overrides", () => {
+    expect(resolveNetworkConfig()).toEqual({
+      network: "testnet",
+      rpcUrl: "https://soroban-testnet.stellar.org",
+      networkPassphrase: Networks.TESTNET
+    });
+
+    expect(resolveNetworkConfig({ network: "mainnet" })).toEqual({
+      network: "mainnet",
+      rpcUrl: "https://soroban-mainnet.stellar.org",
+      networkPassphrase: Networks.PUBLIC
+    });
+
+    expect(
+      resolveNetworkConfig({ network: "testnet", rpcUrl: "http://localhost:3000" })
+    ).toEqual({
+      network: "testnet",
+      rpcUrl: "http://localhost:3000",
+      networkPassphrase: Networks.TESTNET
+    });
+
+    expect(
+      resolveNetworkConfig({ network: "mainnet", networkPassphrase: "my-custom-passphrase" })
+    ).toEqual({
+      network: "mainnet",
+      rpcUrl: "https://soroban-mainnet.stellar.org",
+      networkPassphrase: "my-custom-passphrase"
+    });
+  });
+});


### PR DESCRIPTION
Close: #33 

Summary

This PR adds central network configuration support to Axionvera SDK. The following changes are included:

- `src/utils/networkConfig.ts` with `AxionveraNetwork`, `NetworkConfig`, `getNetworkPassphrase`, `getDefaultRpcUrl`, `resolveNetworkConfig`
- `src/client/stellarClient.ts` now uses `getNetworkPassphrase` from network config in `static getDefaultNetworkPassphrase`
- New tests in `tests/networkConfig.test.ts` for all network config helpers

## Testing

Run:
```bash
npm install
npm test
npm run lint
npm run typecheck
```

## Checklist

- [x] Support testnet and mainnet config
- [x] Centralize network constants
- [x] Config is typed and documented
- [x] Network settings are no longer duplicated
- [x] Switching networks is straightforward
