### PR TITLE
feat(logger): redact secret keys and passphrases, truncate XDR blobs

### DIFF
--- a/packages/core/src/client/logger.test.ts
+++ b/packages/core/src/client/logger.test.ts
@@ -88,5 +88,87 @@ describe('Logger', () => {
       expect(calledArgs[1].AUTHORIZATION).toBe('[REDACTED]');
       expect(calledArgs[1].X_API_KEY).toBe('[REDACTED]');
     });
+
+    test('should redact Stellar secret key on "secret" key', () => {
+      const obj = { secret: 'SCZANGBA5RLGSRSGIDJIS7LJFTD3GVLKIGJTCRWUWDIVRAY3ZKOLA6CK' };
+      logger.debug('Wallet', obj);
+
+      const calledArgs = consoleSpy.mock.calls[0];
+      expect(calledArgs[1].secret).toBe('[REDACTED]');
+      // Ensure the raw secret never appears anywhere in the output
+      expect(JSON.stringify(consoleSpy.mock.calls[0])).not.toContain('SCZANGBA5RLGSRSGIDJIS7LJFTD3GVLKIGJTCRWUWDIVRAY3ZKOLA6CK');
+    });
+
+    test('should redact Stellar secret key on "secretKey" key', () => {
+      const obj = { secretKey: 'SCZANGBA5RLGSRSGIDJIS7LJFTD3GVLKIGJTCRWUWDIVRAY3ZKOLA6CK' };
+      logger.debug('Wallet', obj);
+
+      const calledArgs = consoleSpy.mock.calls[0];
+      expect(calledArgs[1].secretKey).toBe('[REDACTED]');
+      expect(JSON.stringify(consoleSpy.mock.calls[0])).not.toContain('SCZANGBA5RLGSRSGIDJIS7LJFTD3GVLKIGJTCRWUWDIVRAY3ZKOLA6CK');
+    });
+
+    test('should redact network passphrase on "passphrase" key', () => {
+      const obj = { passphrase: 'Test SDF Network ; September 2015', endpoint: 'https://horizon-testnet.stellar.org' };
+      logger.debug('Network config', obj);
+
+      const calledArgs = consoleSpy.mock.calls[0];
+      expect(calledArgs[1].passphrase).toBe('[REDACTED]');
+      expect(calledArgs[1].endpoint).toBe('https://horizon-testnet.stellar.org');
+    });
+
+    test('should redact nested secret and passphrase fields', () => {
+      const obj = {
+        network: {
+          passphrase: 'Public Global Stellar Network ; September 2015',
+          rpcUrl: 'https://soroban-rpc.stellar.org',
+        },
+        wallet: {
+          secretKey: 'SCZANGBA5RLGSRSGIDJIS7LJFTD3GVLKIGJTCRWUWDIVRAY3ZKOLA6CK',
+          publicKey: 'GABC123',
+        },
+      };
+      logger.debug('Config', obj);
+
+      const calledArgs = consoleSpy.mock.calls[0];
+      expect(calledArgs[1].network.passphrase).toBe('[REDACTED]');
+      expect(calledArgs[1].network.rpcUrl).toBe('https://soroban-rpc.stellar.org');
+      expect(calledArgs[1].wallet.secretKey).toBe('[REDACTED]');
+      expect(calledArgs[1].wallet.publicKey).toBe('GABC123');
+    });
+
+    test('secret key must never reach stdout', () => {
+      // Restore real console.debug to verify nothing leaks through
+      jest.restoreAllMocks();
+      const stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+      const sensitiveLogger = new Logger('debug');
+      sensitiveLogger.debug('Signing tx', {
+        secret: 'SCZANGBA5RLGSRSGIDJIS7LJFTD3GVLKIGJTCRWUWDIVRAY3ZKOLA6CK',
+        passphrase: 'Test SDF Network ; September 2015',
+      });
+
+      const allOutput = [
+        ...stdoutSpy.mock.calls.map((c) => String(c[0])),
+        ...stderrSpy.mock.calls.map((c) => String(c[0])),
+      ].join('');
+
+      expect(allOutput).not.toContain('SCZANGBA5RLGSRSGIDJIS7LJFTD3GVLKIGJTCRWUWDIVRAY3ZKOLA6CK');
+      expect(allOutput).not.toContain('Test SDF Network ; September 2015');
+
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    });
+
+    test('should truncate large XDR-like base64 strings', () => {
+      // Simulate a large XDR blob (pure base64, >200 chars)
+      const xdrBlob = 'A'.repeat(300);
+      logger.debug(xdrBlob);
+
+      const logged: string = consoleSpy.mock.calls[0][0];
+      expect(logged).toContain('[TRUNCATED]');
+      expect(logged.length).toBeLessThan(xdrBlob.length + 50); // well shorter than original
+    });
   });
 });

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -33,14 +33,33 @@ export class Logger {
 
   /**
    * Recursively redacts sensitive information from messages and objects.
+   * Also truncates large XDR strings to prevent log bloat.
    */
   private redact(message: any): any {
-    const sensitiveKeys = ['authorization', 'api-key', 'apikey', 'secret', 'password', 'token', 'x-api-key', 'privatekey', 'private_key'];
+    const sensitiveKeys = [
+      'authorization', 'api-key', 'apikey',
+      'secret', 'secretkey', 'secret_key', 'secretaccesskey',
+      'passphrase', 'networkpassphrase',
+      'password',
+      'token',
+      'x-api-key',
+      'privatekey', 'private_key',
+    ];
+
+    /** Maximum length before an XDR-like base64 string is truncated in logs. */
+    const XDR_TRUNCATE_LENGTH = 200;
 
     if (typeof message === 'string') {
-      return message
+      let redacted = message
         .replace(/Bearer\s+[a-zA-Z0-9\-\._~+/]+=*/gi, 'Bearer [REDACTED]')
         .replace(/(api[_-]?key|secret[_-]?key|password|token|private[_-]?key)["']?\s*[:=]\s*["']?([a-zA-Z0-9\-_.]+)["']?/gi, '$1: [REDACTED]');
+
+      // Truncate suspiciously large base64/XDR blobs to avoid log bloat
+      if (redacted.length > XDR_TRUNCATE_LENGTH && /^[A-Za-z0-9+/=]+$/.test(redacted.trim())) {
+        redacted = `${redacted.slice(0, XDR_TRUNCATE_LENGTH)}…[TRUNCATED]`;
+      }
+
+      return redacted;
     }
 
     if (typeof message === 'object' && message !== null) {


### PR DESCRIPTION
Closes #79 
## Summary

Ensures the internal Logger never leaks Stellar secret keys or sensitive network passphrases into consumer console output.

## Changes

- Extended sensitive keys list to include `secret`, `secretKey`, `secret_key`, `passphrase`, `networkPassphrase`, and `secretAccessKey`
- Added XDR truncation: pure base64 strings longer than 200 chars are sliced with `[TRUNCATED]` to prevent log bloat
- Added unit tests covering:
  - `secret` and `secretKey` redaction with real Stellar key format
  - `passphrase` redaction while preserving non-sensitive sibling fields
  - Nested object redaction
  - `process.stdout`/`process.stderr` spy test confirming secrets never reach standard output
  - XDR truncation


