### PR TITLE
Add BrowserWalletConnector and related error handling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,6 +72,14 @@
     "@stellar/stellar-sdk": "^14.6.1",
     "axios": "^1.7.9"
   },
+  "peerDependencies": {
+    "@stellar/freighter-api": "^6.0.1"
+  },
+  "peerDependenciesMeta": {
+    "@stellar/freighter-api": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^11.1.6",
     "size-limit": "^11.1.6",

--- a/packages/core/src/errors/axionveraError.ts
+++ b/packages/core/src/errors/axionveraError.ts
@@ -51,6 +51,8 @@ export class StellarRpcResponseError extends AxionveraError {}
 
 export class StellarRpcTimeoutError extends AxionveraError {}
 
+export class WalletNotInstalledError extends AxionveraError {}
+
 export class FaucetRateLimitError extends AxionveraError {}
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export type { ContractEvent, EventCallback } from './contracts/ContractEventEmit
 
 // Wallet
 export { LocalKeypairWalletConnector } from './wallet/localKeypairWalletConnector';
+export { BrowserWalletConnector } from './wallet/browserWalletConnector';
 export type { WalletConnector } from './wallet/walletConnector';
 
 // Utils
@@ -34,6 +35,7 @@ export {
   StellarRpcNetworkError,
   StellarRpcResponseError,
   StellarRpcTimeoutError,
+  WalletNotInstalledError,
   FaucetRateLimitError,
   toAxionveraError
 } from './errors/axionveraError';

--- a/packages/core/src/wallet/browserWalletConnector.ts
+++ b/packages/core/src/wallet/browserWalletConnector.ts
@@ -1,0 +1,71 @@
+import { WalletConnector } from './walletConnector';
+import { WalletNotInstalledError } from '../errors/axionveraError';
+
+type FreighterApi = {
+  getPublicKey: () => Promise<string>;
+  signTransaction: (
+    transactionXdr: string,
+    networkPassphrase: string
+  ) => Promise<string | { signedTransaction: string }>;
+};
+
+async function loadFreighter(): Promise<FreighterApi> {
+  if (typeof window === 'undefined') {
+    throw new WalletNotInstalledError(
+      'Browser wallet connector requires a browser environment with Freighter installed.'
+    );
+  }
+
+  let freighterModule: unknown;
+  try {
+    freighterModule = await import('@stellar/freighter-api');
+  } catch (error) {
+    throw new WalletNotInstalledError(
+      'Freighter extension is not installed or could not be loaded.'
+    );
+  }
+
+  const provider = (freighterModule as any).default ?? freighterModule;
+  if (
+    !provider ||
+    typeof (provider as any).getPublicKey !== 'function' ||
+    typeof (provider as any).signTransaction !== 'function'
+  ) {
+    throw new WalletNotInstalledError(
+      'Freighter extension is not detected. Please install the Freighter browser extension.'
+    );
+  }
+
+  return provider as FreighterApi;
+}
+
+export class BrowserWalletConnector implements WalletConnector {
+  /** @inheritdoc */
+  async getPublicKey(): Promise<string> {
+    const freighter = await loadFreighter();
+    return freighter.getPublicKey();
+  }
+
+  /** @inheritdoc */
+  async signTransaction(
+    transactionXdr: string,
+    networkPassphrase: string
+  ): Promise<string> {
+    const freighter = await loadFreighter();
+    const result = await freighter.signTransaction(transactionXdr, networkPassphrase);
+
+    if (typeof result === 'string') {
+      return result;
+    }
+
+    if (
+      result &&
+      typeof result === 'object' &&
+      typeof (result as any).signedTransaction === 'string'
+    ) {
+      return (result as any).signedTransaction;
+    }
+
+    throw new Error('Unexpected Freighter signTransaction response.');
+  }
+}

--- a/packages/core/src/wallet/freighter-api.d.ts
+++ b/packages/core/src/wallet/freighter-api.d.ts
@@ -1,0 +1,7 @@
+declare module '@stellar/freighter-api' {
+  export function getPublicKey(): Promise<string>;
+  export function signTransaction(
+    transactionXdr: string,
+    networkPassphrase: string
+  ): Promise<string | { signedTransaction: string }>;
+}

--- a/packages/core/src/wallet/index.ts
+++ b/packages/core/src/wallet/index.ts
@@ -1,2 +1,3 @@
 export { LocalKeypairWalletConnector } from './localKeypairWalletConnector';
+export { BrowserWalletConnector } from './browserWalletConnector';
 export type { WalletConnector } from './walletConnector';

--- a/src/errors/axionveraError.ts
+++ b/src/errors/axionveraError.ts
@@ -59,6 +59,8 @@ export class InvalidSignatureError extends AxionveraError { }
 
 export class SimulationError extends AxionveraError { }
 
+export class WalletNotInstalledError extends AxionveraError { }
+
 export class FaucetRateLimitError extends AxionveraError { }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
     InsufficientFundsError,
     InvalidSignatureError,
     SimulationError,
+    WalletNotInstalledError,
     FaucetRateLimitError,
     toAxionveraError,
     normalizeRpcError,
@@ -33,6 +34,7 @@ export type { VaultConfig, DepositParams, WithdrawParams, VaultInfo } from './co
 
 // Wallet
 export { LocalKeypairWalletConnector } from './wallet/localKeypairWalletConnector';
+export { BrowserWalletConnector } from './wallet/browserWalletConnector';
 export type { WalletConnector } from './wallet/walletConnector';
 
 // Utils

--- a/src/wallet/browserWalletConnector.ts
+++ b/src/wallet/browserWalletConnector.ts
@@ -1,0 +1,71 @@
+import { WalletConnector } from './walletConnector';
+import { WalletNotInstalledError } from '../errors/axionveraError';
+
+type FreighterApi = {
+  getPublicKey: () => Promise<string>;
+  signTransaction: (
+    transactionXdr: string,
+    networkPassphrase: string
+  ) => Promise<string | { signedTransaction: string }>;
+};
+
+async function loadFreighter(): Promise<FreighterApi> {
+  if (typeof window === 'undefined') {
+    throw new WalletNotInstalledError(
+      'Browser wallet connector requires a browser environment with Freighter installed.'
+    );
+  }
+
+  let freighterModule: unknown;
+  try {
+    freighterModule = await import('@stellar/freighter-api');
+  } catch (error) {
+    throw new WalletNotInstalledError(
+      'Freighter extension is not installed or could not be loaded.'
+    );
+  }
+
+  const provider = (freighterModule as any).default ?? freighterModule;
+  if (
+    !provider ||
+    typeof (provider as any).getPublicKey !== 'function' ||
+    typeof (provider as any).signTransaction !== 'function'
+  ) {
+    throw new WalletNotInstalledError(
+      'Freighter extension is not detected. Please install the Freighter browser extension.'
+    );
+  }
+
+  return provider as FreighterApi;
+}
+
+export class BrowserWalletConnector implements WalletConnector {
+  /** @inheritdoc */
+  async getPublicKey(): Promise<string> {
+    const freighter = await loadFreighter();
+    return freighter.getPublicKey();
+  }
+
+  /** @inheritdoc */
+  async signTransaction(
+    transactionXdr: string,
+    networkPassphrase: string
+  ): Promise<string> {
+    const freighter = await loadFreighter();
+    const result = await freighter.signTransaction(transactionXdr, networkPassphrase);
+
+    if (typeof result === 'string') {
+      return result;
+    }
+
+    if (
+      result &&
+      typeof result === 'object' &&
+      typeof (result as any).signedTransaction === 'string'
+    ) {
+      return (result as any).signedTransaction;
+    }
+
+    throw new Error('Unexpected Freighter signTransaction response.');
+  }
+}

--- a/src/wallet/freighter-api.d.ts
+++ b/src/wallet/freighter-api.d.ts
@@ -1,0 +1,7 @@
+declare module '@stellar/freighter-api' {
+  export function getPublicKey(): Promise<string>;
+  export function signTransaction(
+    transactionXdr: string,
+    networkPassphrase: string
+  ): Promise<string | { signedTransaction: string }>;
+}

--- a/tests/browserWalletConnector.test.ts
+++ b/tests/browserWalletConnector.test.ts
@@ -1,0 +1,54 @@
+import { BrowserWalletConnector } from '../src/wallet/browserWalletConnector';
+import { WalletNotInstalledError } from '../src/errors/axionveraError';
+
+const freighterApiMock = {
+  getPublicKey: jest.fn().mockResolvedValue('GTEST_PUBLIC_KEY'),
+  signTransaction: jest.fn().mockResolvedValue('signed-xdr')
+};
+
+jest.mock('@stellar/freighter-api', () => freighterApiMock, { virtual: true });
+
+describe('BrowserWalletConnector', () => {
+  let originalWindow: unknown;
+
+  beforeAll(() => {
+    originalWindow = (global as any).window;
+    (global as any).window = {} as Window;
+  });
+
+  afterAll(() => {
+    if (originalWindow !== undefined) {
+      (global as any).window = originalWindow;
+    } else {
+      delete (global as any).window;
+    }
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    (global as any).window = {} as Window;
+  });
+
+  it('calls freighter.getPublicKey()', async () => {
+    const connector = new BrowserWalletConnector();
+    const publicKey = await connector.getPublicKey();
+
+    expect(publicKey).toBe('GTEST_PUBLIC_KEY');
+    expect(freighterApiMock.getPublicKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls freighter.signTransaction()', async () => {
+    const connector = new BrowserWalletConnector();
+    const signedXdr = await connector.signTransaction('tx-xdr', 'Test SDF Network ; September 2015');
+
+    expect(signedXdr).toBe('signed-xdr');
+    expect(freighterApiMock.signTransaction).toHaveBeenCalledWith('tx-xdr', 'Test SDF Network ; September 2015');
+  });
+
+  it('throws WalletNotInstalledError when no browser environment is available', async () => {
+    delete (global as any).window;
+
+    const connector = new BrowserWalletConnector();
+    await expect(connector.getPublicKey()).rejects.toThrow(WalletNotInstalledError);
+  });
+});


### PR DESCRIPTION
Closes #87

---

#87 

Description:

This PR adds [BrowserWalletConnector](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to enable seamless integration with the Freighter browser wallet extension, providing developers with a plug-and-play connector for browser-based wallet interactions.

Key Changes:
New [BrowserWalletConnector](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) class implementing [WalletConnector](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) interface
Dynamic Freighter API loading with proper error handling
New [WalletNotInstalledError](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for missing extension scenarios
Optional peer dependency on @stellar/freighter-api (v6.0.1)
Unit tests with mocking for CI compatibilit

