### PR TITLE
 Refactor WalletConnector

### DIFF
--- a/src/wallet/walletConnector.ts
+++ b/src/wallet/walletConnector.ts
@@ -6,17 +6,20 @@ import { Keypair, TransactionBuilder } from "@stellar/stellar-sdk";
 export interface WalletConnector {
   /**
    * Gets the public key of the connected account.
-   * @returns The public key
+   * @returns A Promise that resolves to the public key of the connected account.
    */
   getPublicKey(): Promise<string>;
 
   /**
    * Signs a transaction XDR string.
-   * @param transactionXdr - The base64-encoded transaction XDR
+   * 
+   * Must throw a `WalletConnectionError` if the user rejects the signature or if the connection fails.
+   * 
+   * @param xdr - The base64-encoded transaction XDR to sign
    * @param networkPassphrase - The network passphrase
-   * @returns The base64-encoded signed transaction XDR
+   * @returns A Promise that resolves to the base64-encoded signed transaction XDR
    */
-  signTransaction(transactionXdr: string, networkPassphrase: string): Promise<string>;
+  signTransaction(xdr: string, networkPassphrase: string): Promise<string>;
 }
 
 /**
@@ -41,10 +44,10 @@ export class LocalKeypairWalletConnector implements WalletConnector {
 
   /** @inheritdoc */
   async signTransaction(
-    transactionXdr: string,
+    xdr: string,
     networkPassphrase: string
   ): Promise<string> {
-    const tx = TransactionBuilder.fromXDR(transactionXdr, networkPassphrase);
+    const tx = TransactionBuilder.fromXDR(xdr, networkPassphrase);
     tx.sign(this.keypair);
     return tx.toXDR();
   }


### PR DESCRIPTION
closes #77 



**Changes Proposed:**
- **Explicit Typing**: Updated the `signTransaction` method signature to explicitly use `xdr: string` and `networkPassphrase: string` for its inputs.
- **Promise Returns**: Reaffirmed that both `signTransaction` and `getPublicKey` strictly return `Promise<string>`.
- **Error Behavior Documentation**: Added comprehensive JSDoc comments to `signTransaction` to clarify the expected behavior. It is now explicitly documented that the method must throw a `WalletConnectionError` if the user rejects the signature or if the connection fails.
- **Implementation Alignment**: Updated the `LocalKeypairWalletConnector` class to match the refined interface parameter names (renamed `transactionXdr` to `xdr`).

**Acceptance Criteria Met:**
- [x] Reviewed `src/wallet/WalletConnector.ts`.
- [x] Ensured `signTransaction` explicitly types its inputs (`xdr: string`, `networkPassphrase: string`) and returns a Promise.
- [x] Ensured `getPublicKey` returns a Promise.
- [x] Documented the expected behavior to throw `WalletConnectionError` upon signature rejection.
