### PR TITLE
Feat/83 92 100 tx reliability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,36 @@ We provide detailed, runnable examples in the [`examples/`](./examples/) directo
 - ⚖️ **Check Balance**: [balanceExample.ts](./examples/balanceExample.ts)
 - 🔄 **HTTP Retry Logic**: [retryExample.ts](./examples/retryExample.ts)
 
+### Recover a Stuck Transaction with a Fee Bump
+
+When a signed transaction is still pending and the network fee market moves, you can wrap the original signed XDR in a fee bump envelope instead of asking the user to re-sign the contract call.
+
+```typescript
+import { Keypair, Networks } from "@stellar/stellar-sdk";
+import {
+  LocalKeypairWalletConnector,
+  bumpTransactionFee
+} from "axionvera-sdk";
+
+const sponsorWallet = new LocalKeypairWalletConnector(
+  Keypair.fromSecret(process.env.SPONSOR_SECRET_KEY!)
+);
+
+const feeBumpEnvelopeXdr = bumpTransactionFee(userSignedXdr, 500, {
+  feeSource: await sponsorWallet.getPublicKey(),
+  networkPassphrase: Networks.TESTNET
+});
+
+const sponsorSignedXdr = await sponsorWallet.signTransaction(
+  feeBumpEnvelopeXdr,
+  Networks.TESTNET
+);
+
+await client.sendTransaction(sponsorSignedXdr);
+```
+
+This preserves the original user signature on the inner transaction. Only the outer fee bump envelope is signed by the sponsor wallet.
+
 ---
 
 ## 🏗️ Module Architecture
@@ -220,6 +250,7 @@ Automated funding for Testnet and Futurenet.
 Standardized URI generation for mobile wallet integration.
 - `generateTransactionURI(xdr, callbackUrl)`: Generates a `web+stellar:tx` URI.
 - `generatePayURI(destination, amount, assetCode, assetIssuer)`: Generates a `web+stellar:pay` URI.
+- `bumpTransactionFee(signedXdr, newBaseFee, options)`: Wraps a signed transaction XDR in an unsigned fee bump envelope for sponsor signing.
 
 ### `WalletConnector` (Interface)
 Implement this interface to integrate browser extension wallets (like Freighter) or use the provided `LocalKeypairWalletConnector` for backend/scripting services.

--- a/docs/transaction-signing-wrappers.md
+++ b/docs/transaction-signing-wrappers.md
@@ -192,16 +192,25 @@ console.log(`Success: ${result.successful}`);
 ### Fee Bump Transaction
 
 ```typescript
-// Create fee bump transaction
-const feeBumpXdr = await signer.createFeeBumpTransaction({
-  innerTransaction: originalTransactionXdr,
-  feeSource: 'G...',
-  baseFee: 100
+import { Networks } from '@stellar/stellar-sdk';
+import { bumpTransactionFee } from 'axionvera-sdk';
+
+// Wrap the already-signed inner transaction without touching the original payload
+const feeBumpEnvelopeXdr = bumpTransactionFee(originalSignedXdr, 500, {
+  feeSource: 'GSPONSOR...',
+  networkPassphrase: Networks.TESTNET
 });
 
-// Submit the fee bump transaction
-const result = await signer.submitSignedTransaction(feeBumpXdr);
+// The sponsor signs only the outer fee bump envelope
+const sponsorSignedXdr = await sponsorWallet.signTransaction(
+  feeBumpEnvelopeXdr,
+  Networks.TESTNET
+);
+
+const result = await signer.submitSignedTransaction(sponsorSignedXdr);
 ```
+
+This pattern is useful when a user-signed transaction is already in flight and a backend sponsor wallet needs to resubmit it with a higher fee during congestion.
 
 ### Batch Processing
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -111,6 +111,36 @@ STELLAR_PUBLIC_KEY=G... \
 npx ts-node examples/balanceExample.ts
 ```
 
+## 7) Recover a stuck transaction with a sponsor fee bump
+
+Use `bumpTransactionFee` when the user already signed the original contract transaction, but the transaction is stuck in the mempool and a backend sponsor needs to raise the fee.
+
+```ts
+import { Networks } from "@stellar/stellar-sdk";
+import { bumpTransactionFee } from "axionvera-sdk";
+
+const feeBumpEnvelopeXdr = bumpTransactionFee(userSignedXdr, 500, {
+  feeSource: sponsorPublicKey,
+  networkPassphrase: Networks.TESTNET
+});
+
+const sponsorSignedXdr = await sponsorWallet.signTransaction(
+  feeBumpEnvelopeXdr,
+  Networks.TESTNET
+);
+
+await client.sendTransaction(sponsorSignedXdr);
+```
+
+Workflow:
+
+1. The user signs the original inner transaction once.
+2. Your backend wraps that signed XDR with `bumpTransactionFee(...)`.
+3. The sponsor wallet signs only the outer fee bump envelope.
+4. Submit the sponsor-signed fee bump XDR with `client.sendTransaction(...)`.
+
+This keeps the original contract payload intact while letting enterprise apps react to volatile fee markets.
+
 ## TODO
 
 - Add CLI examples that compile to plain JS under `dist/`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -128,6 +128,36 @@ We provide detailed, runnable examples in the [`examples/`](./examples/) directo
 - ⚖️ **Check Balance**: [balanceExample.ts](./examples/balanceExample.ts)
 - 🔄 **HTTP Retry Logic**: [retryExample.ts](./examples/retryExample.ts)
 
+### Recover a Stuck Transaction with a Fee Bump
+
+When a signed transaction is still pending and the network fee market moves, you can wrap the original signed XDR in a fee bump envelope instead of asking the user to re-sign the contract call.
+
+```typescript
+import { Keypair, Networks } from "@stellar/stellar-sdk";
+import {
+  LocalKeypairWalletConnector,
+  bumpTransactionFee
+} from "@axionvera/core";
+
+const sponsorWallet = new LocalKeypairWalletConnector(
+  Keypair.fromSecret(process.env.SPONSOR_SECRET_KEY!)
+);
+
+const feeBumpEnvelopeXdr = bumpTransactionFee(userSignedXdr, 500, {
+  feeSource: await sponsorWallet.getPublicKey(),
+  networkPassphrase: Networks.TESTNET
+});
+
+const sponsorSignedXdr = await sponsorWallet.signTransaction(
+  feeBumpEnvelopeXdr,
+  Networks.TESTNET
+);
+
+await client.sendTransaction(sponsorSignedXdr);
+```
+
+This preserves the original user signature on the inner transaction. Only the outer fee bump envelope is signed by the sponsor wallet.
+
 ---
 
 ## 📚 API Reference
@@ -158,6 +188,7 @@ Automated funding for Testnet and Futurenet.
 Standardized URI generation for mobile wallet integration.
 - `generateTransactionURI(xdr, callbackUrl)`: Generates a `web+stellar:tx` URI.
 - `generatePayURI(destination, amount, assetCode, assetIssuer)`: Generates a `web+stellar:pay` URI.
+- `bumpTransactionFee(signedXdr, newBaseFee, options)`: Wraps a signed transaction XDR in an unsigned fee bump envelope for sponsor signing.
 
 ### `WalletConnector` (Interface)
 Implement this interface to integrate browser extension wallets (like Freighter) or use the provided `LocalKeypairWalletConnector` for backend/scripting services.

--- a/packages/core/src/client/stellarClient.ts
+++ b/packages/core/src/client/stellarClient.ts
@@ -6,6 +6,7 @@ import {
   Keypair,
   nativeToScVal,
   rpc,
+  SorobanDataBuilder,
   Transaction,
   TransactionBuilder,
   xdr
@@ -18,7 +19,7 @@ import {
 } from "../utils/networkConfig";
 import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG, createConcurrencyControlledClient } from "../utils/concurrencyQueue";
 import { RetryConfig, createHttpClientWithRetry, retry } from "../utils/httpInterceptor";
-import { NetworkError, toAxionveraError, InsecureNetworkError, AxionveraError } from "../errors/axionveraError";
+import { NetworkError, toAxionveraError, InsecureNetworkError, AxionveraError, ValidationError } from "../errors/axionveraError";
 import { LogLevel, Logger } from "../utils/logger";
 import { WebSocketManager, EventFilter, SorobanEvent, WebSocketConfig } from "./websocket";
 import { CloudWatchConfig } from "../utils/logging/cloudwatch";
@@ -29,6 +30,8 @@ import {
   sortByTimestamp,
   filterByActionType
 } from "../utils/transactionHistory";
+
+const DEFAULT_FEE_BUFFER_MULTIPLIER = 1.15;
 
 /**
  * Checks if a URL points to a localhost address.
@@ -57,6 +60,10 @@ export type StellarClientOptions = {
   webSocketConfig?: WebSocketConfig;
   cloudWatchConfig?: CloudWatchConfig;
   customHeaders?: Record<string, string>;
+  /** Multiplier applied to simulated Soroban resources and fees (default: 1.15). */
+  feeBufferMultiplier?: number;
+  /** Hard ceiling for the total prepared fee in stroops. */
+  maxFeeLimit?: number;
   allowHttp?: boolean;
 };
 
@@ -105,6 +112,10 @@ export class StellarClient extends BaseStellarRpcClient {
   private readonly logger: Logger;
   /** WebSocket manager for real-time events. */
   private webSocketManager: WebSocketManager | null = null;
+  /** Multiplier applied to simulated Soroban resources and fees. */
+  private readonly feeBufferMultiplier: number;
+  /** Optional hard ceiling for the total prepared fee. */
+  private readonly maxFeeLimit?: bigint;
 
    /**
     * Creates a new StellarClient instance.
@@ -149,6 +160,19 @@ export class StellarClient extends BaseStellarRpcClient {
     this.retryConfig = options?.retryConfig ?? {};
     this.httpClient = createHttpClientWithRetry(this.retryConfig);
     this.logger = new Logger(options?.logLevel ?? 'none', options?.cloudWatchConfig);
+    this.feeBufferMultiplier = options?.feeBufferMultiplier ?? DEFAULT_FEE_BUFFER_MULTIPLIER;
+
+    if (!Number.isFinite(this.feeBufferMultiplier) || this.feeBufferMultiplier < 1) {
+      throw new ValidationError("feeBufferMultiplier must be a finite number greater than or equal to 1");
+    }
+
+    if (options?.maxFeeLimit !== undefined) {
+      if (!Number.isInteger(options.maxFeeLimit) || options.maxFeeLimit <= 0) {
+        throw new ValidationError("maxFeeLimit must be a positive integer");
+      }
+
+      this.maxFeeLimit = BigInt(options.maxFeeLimit);
+    }
 
     this.logger.info(`Initializing StellarClient for ${this.network} at ${this.rpcUrl}`);
 
@@ -342,8 +366,19 @@ export class StellarClient extends BaseStellarRpcClient {
    */
   async prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction> {
     this.logger.debug("Preparing transaction");
+    if (tx instanceof FeeBumpTransaction) {
+      return this.executeWithErrorHandling(
+        () => this.rpc.prepareTransaction(tx),
+        "Failed to prepare transaction"
+      );
+    }
+
     return this.executeWithErrorHandling(
-      () => this.rpc.prepareTransaction(tx),
+      async () => {
+        const simulation = await this.simulateTransaction(tx);
+        const assembledTx = rpc.assembleTransaction(tx, simulation).build();
+        return this.applyFeeBuffer(assembledTx);
+      },
       "Failed to prepare transaction"
     );
   }
@@ -676,6 +711,53 @@ export class StellarClient extends BaseStellarRpcClient {
       throw toAxionveraError(error, fallbackMessage);
     }
   }
+
+  private applyFeeBuffer(tx: Transaction): Transaction {
+    const sorobanData = tx.toEnvelope().v1().tx().ext().value();
+    if (!sorobanData) {
+      return tx;
+    }
+
+    const resources = sorobanData.resources();
+    const simulatedResourceFee = sorobanData.resourceFee().toBigInt();
+    const simulatedTotalFee = BigInt(tx.fee);
+    const simulatedBaseFee = simulatedTotalFee > simulatedResourceFee
+      ? simulatedTotalFee - simulatedResourceFee
+      : BigInt(0);
+
+    const bufferedResourceFee = multiplyAndCeil(simulatedResourceFee, this.feeBufferMultiplier);
+    const bufferedBaseFee = multiplyAndCeil(simulatedBaseFee, this.feeBufferMultiplier);
+    const bufferedTotalFee = bufferedBaseFee + bufferedResourceFee;
+
+    if (this.maxFeeLimit !== undefined) {
+      if (this.maxFeeLimit < simulatedTotalFee) {
+        throw new ValidationError(
+          `maxFeeLimit (${this.maxFeeLimit.toString()}) is below the simulated minimum fee (${simulatedTotalFee.toString()})`
+        );
+      }
+
+      if (bufferedTotalFee > this.maxFeeLimit) {
+        throw new ValidationError(
+          `Buffered fee (${bufferedTotalFee.toString()}) exceeds maxFeeLimit (${this.maxFeeLimit.toString()})`
+        );
+      }
+    }
+
+    const bufferedSorobanData = new SorobanDataBuilder(sorobanData)
+      .setResources(
+        multiplyAndCeil(resources.instructions(), this.feeBufferMultiplier),
+        multiplyAndCeil(resources.diskReadBytes(), this.feeBufferMultiplier),
+        multiplyAndCeil(resources.writeBytes(), this.feeBufferMultiplier)
+      )
+      .setResourceFee(bufferedResourceFee.toString())
+      .build();
+
+    return TransactionBuilder.cloneFrom(tx, {
+      fee: bufferedBaseFee.toString(),
+      networkPassphrase: tx.networkPassphrase,
+      sorobanData: bufferedSorobanData
+    }).build();
+  }
 }
 
 /**
@@ -690,4 +772,37 @@ function extractCursor(url: string): string | undefined {
   } catch {
     return undefined;
   }
+}
+
+function multiplyAndCeil(value: number | bigint | string, multiplier: number): bigint {
+  const scaledValue = typeof value === "bigint" ? value : BigInt(String(value));
+  if (scaledValue < BigInt(0)) {
+    throw new ValidationError("Cannot buffer a non-finite or negative resource value");
+  }
+
+  const { numerator, denominator } = toFraction(multiplier);
+  return (scaledValue * numerator + (denominator - BigInt(1))) / denominator;
+}
+
+function toFraction(multiplier: number): { numerator: bigint; denominator: bigint } {
+  if (!Number.isFinite(multiplier) || multiplier < 0) {
+    throw new ValidationError("feeBufferMultiplier must be a finite number greater than or equal to 0");
+  }
+
+  const decimalString = multiplier.toString().includes("e")
+    ? multiplier.toFixed(12).replace(/0+$/, "").replace(/\.$/, "")
+    : multiplier.toString();
+  const [wholePart, fractionalPart = ""] = decimalString.split(".");
+
+  if (!/^\d+$/.test(wholePart) || !/^\d*$/.test(fractionalPart)) {
+    throw new ValidationError("feeBufferMultiplier must be a valid decimal number");
+  }
+
+  const denominator = BigInt(10) ** BigInt(fractionalPart.length);
+  const numerator = BigInt(`${wholePart}${fractionalPart}`);
+
+  return {
+    numerator,
+    denominator: denominator === BigInt(0) ? BigInt(1) : denominator
+  };
 }

--- a/packages/core/src/client/stellarClient.ts
+++ b/packages/core/src/client/stellarClient.ts
@@ -19,7 +19,7 @@ import {
 } from "../utils/networkConfig";
 import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG, createConcurrencyControlledClient } from "../utils/concurrencyQueue";
 import { RetryConfig, createHttpClientWithRetry, retry } from "../utils/httpInterceptor";
-import { NetworkError, toAxionveraError, InsecureNetworkError, AxionveraError, ValidationError } from "../errors/axionveraError";
+import { NetworkError, toAxionveraError, InsecureNetworkError, AxionveraError, TransactionTimeoutError, ValidationError } from "../errors/axionveraError";
 import { LogLevel, Logger } from "../utils/logger";
 import { WebSocketManager, EventFilter, SorobanEvent, WebSocketConfig } from "./websocket";
 import { CloudWatchConfig } from "../utils/logging/cloudwatch";
@@ -71,6 +71,13 @@ export type TransactionSendResult = {
   hash: string;
   status: string;
   raw: unknown;
+};
+
+type TransactionResponseRecord = Record<string, unknown>;
+
+export type TransactionPollResult = TransactionResponseRecord & {
+  status: string;
+  ledger: number | null;
 };
 
 /**
@@ -429,38 +436,90 @@ export class StellarClient extends BaseStellarRpcClient {
       intervalMs?: number;
       onProgress?: (status: string, ledger: number) => void | Promise<void>;
     }
-  ): Promise<unknown> {
+  ): Promise<TransactionPollResult> {
     return this.executeWithErrorHandling(async () => {
       const timeoutMs = params?.timeoutMs ?? 30_000;
       const intervalMs = params?.intervalMs ?? 1_000;
       const onProgress = params?.onProgress;
 
-      const deadline = Date.now() + timeoutMs;
+      validatePollingInterval(timeoutMs, "timeoutMs", true);
+      validatePollingInterval(intervalMs, "intervalMs", false);
 
-      while (Date.now() < deadline) {
-        const res = await this.getTransaction(hash);
+      return await new Promise<TransactionPollResult>((resolve, reject) => {
+        let settled = false;
+        let pollTimer: ReturnType<typeof setTimeout> | undefined;
 
-        const status = (res as any)?.status ?? "UNKNOWN";
-        const ledger = (res as any)?.ledger ?? 0;
+        const clearTimers = () => {
+          clearTimeout(timeoutTimer);
+          if (pollTimer) {
+            clearTimeout(pollTimer);
+          }
+        };
 
-        // ✅ NON-BLOCKING progress callback
-        if (onProgress) {
-          Promise.resolve()
-            .then(() => onProgress(status, ledger))
-            .catch((err) => {
-              this.logger.warn("onProgress callback error", err);
-            });
-        }
+        const settle = (callback: () => void) => {
+          if (settled) {
+            return;
+          }
 
-        // existing exit logic
-        if (status && status !== "NOT_FOUND") {
-          return res;
-        }
+          settled = true;
+          clearTimers();
+          callback();
+        };
 
-        await new Promise((r) => setTimeout(r, intervalMs));
-      }
+        const scheduleNextPoll = () => {
+          if (settled) {
+            return;
+          }
 
-      throw new NetworkError(`Timed out waiting for transaction ${hash}`);
+          pollTimer = setTimeout(() => {
+            void pollOnce();
+          }, intervalMs);
+        };
+
+        const timeoutTimer = setTimeout(() => {
+          settle(() => {
+            reject(
+              new TransactionTimeoutError(
+                `Timed out waiting for transaction ${hash} after ${timeoutMs}ms`
+              )
+            );
+          });
+        }, timeoutMs);
+
+        const pollOnce = async () => {
+          try {
+            const res = await this.getTransaction(hash);
+            if (settled) {
+              return;
+            }
+
+            const parsed = parseTransactionPollResult(res);
+
+            if (onProgress) {
+              Promise.resolve()
+                .then(() => onProgress(parsed.status, parsed.ledger ?? 0))
+                .catch((err) => {
+                  this.logger.warn("onProgress callback error", err);
+                });
+            }
+
+            if (parsed.status === "SUCCESS" || parsed.status === "FAILED") {
+              settle(() => resolve(parsed));
+              return;
+            }
+
+            scheduleNextPoll();
+          } catch (error) {
+            if (settled) {
+              return;
+            }
+
+            settle(() => reject(error));
+          }
+        };
+
+        void pollOnce();
+      });
     }, `Failed while polling transaction ${hash}`);
   }
   /**
@@ -805,4 +864,41 @@ function toFraction(multiplier: number): { numerator: bigint; denominator: bigin
     numerator,
     denominator: denominator === BigInt(0) ? BigInt(1) : denominator
   };
+}
+
+function validatePollingInterval(value: number, fieldName: string, allowZero: boolean): void {
+  const valid = Number.isFinite(value) && (allowZero ? value >= 0 : value > 0);
+  if (!valid) {
+    throw new ValidationError(`${fieldName} must be a finite ${allowZero ? "non-negative" : "positive"} number`);
+  }
+}
+
+function parseTransactionPollResult(response: unknown): TransactionPollResult {
+  const record = isRecord(response) ? response : {};
+  const status = typeof record.status === "string" ? record.status : "UNKNOWN";
+
+  return {
+    ...record,
+    status,
+    ledger: normalizeLedger(record.ledger)
+  };
+}
+
+function normalizeLedger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is TransactionResponseRecord {
+  return typeof value === "object" && value !== null;
 }

--- a/packages/core/src/errors/axionveraError.ts
+++ b/packages/core/src/errors/axionveraError.ts
@@ -51,6 +51,8 @@ export class StellarRpcResponseError extends AxionveraError {}
 
 export class StellarRpcTimeoutError extends AxionveraError {}
 
+export class TransactionTimeoutError extends StellarRpcTimeoutError {}
+
 export class WalletNotInstalledError extends AxionveraError {}
 
 export class FaucetRateLimitError extends AxionveraError {}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,7 +21,8 @@ export type { WalletConnector } from './wallet/walletConnector';
 // Utils
 export { ConcurrencyQueue, createConcurrencyControlledClient } from './utils/concurrencyQueue';
 export { retry, createHttpClientWithRetry } from './utils/httpInterceptor';
-export { buildContractCallOperation, buildContractCallTransaction, buildContractAuthPayload, toScVal } from './utils/transactionBuilder';
+export { buildContractCallOperation, buildContractCallTransaction, buildContractAuthPayload, bumpTransactionFee, toScVal } from './utils/transactionBuilder';
+export type { BumpTransactionFeeOptions } from './utils/transactionBuilder';
 export { getDefaultRpcUrl, getNetworkPassphrase, resolveNetworkConfig } from './utils/networkConfig';
 export { generateTransactionURI, generatePayURI } from './utils/sep7';
 export { decodeXdrBase64, clearXdrCache, getXdrCacheSize } from './utils/xdrCache';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export {
   StellarRpcNetworkError,
   StellarRpcResponseError,
   StellarRpcTimeoutError,
+  TransactionTimeoutError,
   WalletNotInstalledError,
   FaucetRateLimitError,
   toAxionveraError

--- a/packages/core/src/transaction/transactionSigner.ts
+++ b/packages/core/src/transaction/transactionSigner.ts
@@ -1,19 +1,18 @@
 import {
   Account,
-  Address,
-  Contract,
-  FeeBumpTransaction,
-  Keypair,
   Transaction,
   TransactionBuilder,
   rpc,
-  xdr,
   Operation
 } from "@stellar/stellar-sdk";
 
 import { StellarClient } from "../client/stellarClient";
 import { WalletConnector } from "../wallet/walletConnector";
-import { buildContractCallOperation, toScVal, ContractCallArg } from "../utils/transactionBuilder";
+import {
+  buildContractCallOperation,
+  bumpTransactionFee,
+  ContractCallArg
+} from "../utils/transactionBuilder";
 
 /**
  * Configuration for building and signing transactions.
@@ -277,27 +276,17 @@ export class TransactionSigner {
    * @returns The signed fee bump transaction XDR
    */
   async createFeeBumpTransaction(params: FeeBumpParams): Promise<string> {
-    // Parse the inner transaction
-    const innerTransaction = TransactionBuilder.fromXDR(
+    const feeBumpEnvelopeXdr = bumpTransactionFee(
       params.innerTransaction,
-      this.client.networkPassphrase
+      params.baseFee,
+      {
+        feeSource: params.feeSource,
+        networkPassphrase: this.client.networkPassphrase
+      }
     );
 
-    // Get fee source account
-    const feeSourceAccount = await this.client.rpc.getAccount(params.feeSource);
-
-    // Build the fee bump transaction
-    const feeBumpTx = new FeeBumpTransaction.Builder(
-      feeSourceAccount,
-      params.baseFee.toString(),
-      this.client.networkPassphrase
-    )
-      .setInnerTransaction(innerTransaction)
-      .build();
-
-    // Sign the fee bump transaction
     return await this.wallet.signTransaction(
-      feeBumpTx.toXDR(),
+      feeBumpEnvelopeXdr,
       this.client.networkPassphrase
     );
   }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,6 +1,6 @@
 export { ConcurrencyQueue, createConcurrencyControlledClient } from './concurrencyQueue';
 export { retry, createHttpClientWithRetry } from './httpInterceptor';
-export { buildContractCallOperation, buildContractCallTransaction, toScVal } from './transactionBuilder';
+export { buildContractCallOperation, buildContractCallTransaction, bumpTransactionFee, toScVal } from './transactionBuilder';
 export { getDefaultRpcUrl, getNetworkPassphrase, resolveNetworkConfig } from './networkConfig';
 export { generateTransactionURI, generatePayURI } from './sep7';
 export { Logger } from './logger';

--- a/packages/core/src/utils/transactionBuilder.ts
+++ b/packages/core/src/utils/transactionBuilder.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   Address,
+  FeeBumpTransaction,
   Contract,
   Transaction,
   TransactionBuilder,
@@ -31,6 +32,16 @@ export type BuildContractCallParams = {
   fee?: number;
   /** Transaction timeout in seconds (default: 60) */
   timeoutInSeconds?: number;
+};
+
+/**
+ * Options for wrapping a signed transaction in a fee bump envelope.
+ */
+export type BumpTransactionFeeOptions = {
+  /** The public key of the account sponsoring the higher fee */
+  feeSource: string;
+  /** The network passphrase used to parse and rebuild the transaction */
+  networkPassphrase: string;
 };
 
 /**
@@ -112,6 +123,56 @@ export function buildContractCallTransaction(
     .addOperation(operation)
     .setTimeout(timeoutInSeconds)
     .build();
+}
+
+/**
+ * Wraps a signed transaction in an unsigned fee bump envelope.
+ *
+ * The returned XDR preserves the original user signature on the inner
+ * transaction. Only the outer fee bump envelope still needs to be signed
+ * by the sponsoring account before submission.
+ *
+ * @param signedXdr - The already-signed inner transaction XDR
+ * @param newBaseFee - The replacement base fee in stroops
+ * @param options - Fee bump configuration
+ * @returns The unsigned fee bump transaction XDR
+ */
+export function bumpTransactionFee(
+  signedXdr: string,
+  newBaseFee: number,
+  options: BumpTransactionFeeOptions
+): string {
+  if (!signedXdr) {
+    throw new Error("signedXdr is required");
+  }
+
+  if (!Number.isInteger(newBaseFee) || newBaseFee <= 0) {
+    throw new Error("newBaseFee must be a positive integer");
+  }
+
+  if (!options.feeSource) {
+    throw new Error("feeSource is required");
+  }
+
+  const innerTransaction = TransactionBuilder.fromXDR(
+    signedXdr,
+    options.networkPassphrase
+  );
+
+  if (innerTransaction instanceof FeeBumpTransaction) {
+    throw new Error("signedXdr must be a signed inner transaction, not an existing fee bump transaction");
+  }
+
+  if (innerTransaction.signatures.length === 0) {
+    throw new Error("signedXdr must include at least one signature before applying a fee bump");
+  }
+
+  return TransactionBuilder.buildFeeBumpTransaction(
+    options.feeSource,
+    newBaseFee.toString(),
+    innerTransaction,
+    options.networkPassphrase
+  ).toXDR();
 }
 
 /**

--- a/src/client/stellarClient.ts
+++ b/src/client/stellarClient.ts
@@ -4,6 +4,7 @@ import {
   Keypair,
   Networks,
   rpc,
+  SorobanDataBuilder,
   Transaction,
   TransactionBuilder
 } from "@stellar/stellar-sdk";
@@ -11,10 +12,12 @@ import {
 import { AxionveraNetwork, resolveNetworkConfig } from "../utils/networkConfig";
 import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG, createConcurrencyControlledClient } from "../utils/concurrencyQueue";
 import { RetryConfig, createHttpClientWithRetry, retry } from "../utils/httpInterceptor";
-import { normalizeRpcError, normalizeTransactionError, TimeoutError, InsecureNetworkError, AxionveraError, AxionveraRPCError, SimulationFailedError } from "../errors/axionveraError";
+import { normalizeRpcError, normalizeTransactionError, TimeoutError, InsecureNetworkError, AxionveraError, AxionveraRPCError, SimulationFailedError, ValidationError, toAxionveraError } from "../errors/axionveraError";
 import { WebSocketManager } from "./websocket/websocketManager";
 import { WebSocketConfig } from "./websocket/types";
 import { Logger } from "../utils/logger";
+
+const DEFAULT_FEE_BUFFER_MULTIPLIER = 1.15;
 
 /**
  * Checks if a URL points to a localhost address.
@@ -41,6 +44,10 @@ export type StellarClientOptions = {
   retryConfig?: Partial<RetryConfig>;
   webSocketConfig?: WebSocketConfig;
   logger?: Logger;
+  /** Multiplier applied to simulated Soroban resources and fees (default: 1.15). */
+  feeBufferMultiplier?: number;
+  /** Hard ceiling for the total prepared fee in stroops. */
+  maxFeeLimit?: number;
   allowHttp?: boolean;
 };
 
@@ -85,6 +92,10 @@ export class StellarClient {
   readonly webSocketManager?: WebSocketManager;
   /** Logger instance for debugging and monitoring. */
   readonly logger: Logger;
+  /** Multiplier applied to simulated Soroban resources and fees. */
+  readonly feeBufferMultiplier: number;
+  /** Optional hard ceiling for the total prepared fee. */
+  readonly maxFeeLimit?: bigint;
 
   /**
    * Creates a new StellarClient instance.
@@ -123,6 +134,19 @@ export class StellarClient {
     this.retryConfig = options?.retryConfig ?? {};
     this.httpClient = createHttpClientWithRetry(this.retryConfig);
     this.logger = options?.logger ?? new Logger();
+    this.feeBufferMultiplier = options?.feeBufferMultiplier ?? DEFAULT_FEE_BUFFER_MULTIPLIER;
+
+    if (!Number.isFinite(this.feeBufferMultiplier) || this.feeBufferMultiplier < 1) {
+      throw new ValidationError("feeBufferMultiplier must be a finite number greater than or equal to 1");
+    }
+
+    if (options?.maxFeeLimit !== undefined) {
+      if (!Number.isInteger(options.maxFeeLimit) || options.maxFeeLimit <= 0) {
+        throw new ValidationError("maxFeeLimit must be a positive integer");
+      }
+
+      this.maxFeeLimit = BigInt(options.maxFeeLimit);
+    }
 
     // Initialize WebSocket manager if configuration is provided
     if (options?.webSocketConfig) {
@@ -233,7 +257,25 @@ export class StellarClient {
    * @returns The prepared transaction
    */
   async prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction> {
-    return this.rpc.prepareTransaction(tx);
+    if (tx instanceof FeeBumpTransaction) {
+      try {
+        return await this.rpc.prepareTransaction(tx);
+      } catch (error) {
+        throw toAxionveraError(error, "Failed to prepare transaction");
+      }
+    }
+
+    try {
+      const simulation = await this.simulateTransaction(tx);
+      const assembledTx = rpc.assembleTransaction(tx, simulation).build();
+      return this.applyFeeBuffer(assembledTx);
+    } catch (error) {
+      if (error instanceof AxionveraError) {
+        throw error;
+      }
+
+      throw toAxionveraError(error, "Failed to prepare transaction");
+    }
   }
 
   /**
@@ -315,6 +357,53 @@ export class StellarClient {
     throw new TimeoutError(`Timed out waiting for transaction ${hash} after ${timeoutMs}ms`);
   }
 
+  private applyFeeBuffer(tx: Transaction): Transaction {
+    const sorobanData = tx.toEnvelope().v1().tx().ext().value();
+    if (!sorobanData) {
+      return tx;
+    }
+
+    const resources = sorobanData.resources();
+    const simulatedResourceFee = sorobanData.resourceFee().toBigInt();
+    const simulatedTotalFee = BigInt(tx.fee);
+    const simulatedBaseFee = simulatedTotalFee > simulatedResourceFee
+      ? simulatedTotalFee - simulatedResourceFee
+      : BigInt(0);
+
+    const bufferedResourceFee = multiplyAndCeil(simulatedResourceFee, this.feeBufferMultiplier);
+    const bufferedBaseFee = multiplyAndCeil(simulatedBaseFee, this.feeBufferMultiplier);
+    const bufferedTotalFee = bufferedBaseFee + bufferedResourceFee;
+
+    if (this.maxFeeLimit !== undefined) {
+      if (this.maxFeeLimit < simulatedTotalFee) {
+        throw new ValidationError(
+          `maxFeeLimit (${this.maxFeeLimit.toString()}) is below the simulated minimum fee (${simulatedTotalFee.toString()})`
+        );
+      }
+
+      if (bufferedTotalFee > this.maxFeeLimit) {
+        throw new ValidationError(
+          `Buffered fee (${bufferedTotalFee.toString()}) exceeds maxFeeLimit (${this.maxFeeLimit.toString()})`
+        );
+      }
+    }
+
+    const bufferedSorobanData = new SorobanDataBuilder(sorobanData)
+      .setResources(
+        multiplyAndCeil(resources.instructions(), this.feeBufferMultiplier),
+        multiplyAndCeil(resources.diskReadBytes(), this.feeBufferMultiplier),
+        multiplyAndCeil(resources.writeBytes(), this.feeBufferMultiplier)
+      )
+      .setResourceFee(bufferedResourceFee.toString())
+      .build();
+
+    return TransactionBuilder.cloneFrom(tx, {
+      fee: bufferedBaseFee.toString(),
+      networkPassphrase: tx.networkPassphrase,
+      sorobanData: bufferedSorobanData
+    }).build();
+  }
+
   /**
    * Signs a transaction using a local Keypair.
    * This is a convenience method for local signing without a wallet connector.
@@ -382,4 +471,37 @@ export class StellarClient {
       message: 'Stats not available from wrapped client'
     };
   }
+}
+
+function multiplyAndCeil(value: number | bigint | string, multiplier: number): bigint {
+  const scaledValue = typeof value === "bigint" ? value : BigInt(String(value));
+  if (scaledValue < BigInt(0)) {
+    throw new ValidationError("Cannot buffer a non-finite or negative resource value");
+  }
+
+  const { numerator, denominator } = toFraction(multiplier);
+  return (scaledValue * numerator + (denominator - BigInt(1))) / denominator;
+}
+
+function toFraction(multiplier: number): { numerator: bigint; denominator: bigint } {
+  if (!Number.isFinite(multiplier) || multiplier < 0) {
+    throw new ValidationError("feeBufferMultiplier must be a finite number greater than or equal to 0");
+  }
+
+  const decimalString = multiplier.toString().includes("e")
+    ? multiplier.toFixed(12).replace(/0+$/, "").replace(/\.$/, "")
+    : multiplier.toString();
+  const [wholePart, fractionalPart = ""] = decimalString.split(".");
+
+  if (!/^\d+$/.test(wholePart) || !/^\d*$/.test(fractionalPart)) {
+    throw new ValidationError("feeBufferMultiplier must be a valid decimal number");
+  }
+
+  const denominator = BigInt(10) ** BigInt(fractionalPart.length);
+  const numerator = BigInt(`${wholePart}${fractionalPart}`);
+
+  return {
+    numerator,
+    denominator: denominator === BigInt(0) ? BigInt(1) : denominator
+  };
 }

--- a/src/client/stellarClient.ts
+++ b/src/client/stellarClient.ts
@@ -12,7 +12,7 @@ import {
 import { AxionveraNetwork, resolveNetworkConfig } from "../utils/networkConfig";
 import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG, createConcurrencyControlledClient } from "../utils/concurrencyQueue";
 import { RetryConfig, createHttpClientWithRetry, retry } from "../utils/httpInterceptor";
-import { normalizeRpcError, normalizeTransactionError, TimeoutError, InsecureNetworkError, AxionveraError, AxionveraRPCError, SimulationFailedError, ValidationError, toAxionveraError } from "../errors/axionveraError";
+import { normalizeRpcError, normalizeTransactionError, TransactionTimeoutError, InsecureNetworkError, AxionveraError, AxionveraRPCError, SimulationFailedError, ValidationError, toAxionveraError } from "../errors/axionveraError";
 import { WebSocketManager } from "./websocket/websocketManager";
 import { WebSocketConfig } from "./websocket/types";
 import { Logger } from "../utils/logger";
@@ -55,6 +55,13 @@ export type TransactionSendResult = {
   hash: string;
   status: string;
   raw: unknown;
+};
+
+type TransactionResponseRecord = Record<string, unknown>;
+
+export type TransactionPollResult = TransactionResponseRecord & {
+  status: string;
+  ledger: number | null;
 };
 
 /**
@@ -335,26 +342,84 @@ export class StellarClient {
    * @param params.timeoutMs - Maximum time to wait in milliseconds (default: 30000)
    * @param params.intervalMs - Time between polls in milliseconds (default: 1000)
    * @returns The transaction result when it reaches a final state
-   * @throws TimeoutError if the transaction times out
+   * @throws TransactionTimeoutError if the transaction does not reach a final status in time
    */
   async pollTransaction(
     hash: string,
     params?: { timeoutMs?: number; intervalMs?: number }
-  ): Promise<unknown> {
+  ): Promise<TransactionPollResult> {
     const timeoutMs = params?.timeoutMs ?? 30_000;
     const intervalMs = params?.intervalMs ?? 1_000;
-    const deadline = Date.now() + timeoutMs;
 
-    while (Date.now() < deadline) {
-      const res = await this.getTransaction(hash);
-      const status = (res as any)?.status;
-      if (status && status !== "NOT_FOUND") {
-        return res;
-      }
-      await new Promise((r) => setTimeout(r, intervalMs));
-    }
+    validatePollingInterval(timeoutMs, "timeoutMs", true);
+    validatePollingInterval(intervalMs, "intervalMs", false);
 
-    throw new TimeoutError(`Timed out waiting for transaction ${hash} after ${timeoutMs}ms`);
+    return new Promise<TransactionPollResult>((resolve, reject) => {
+      let settled = false;
+      let pollTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const clearTimers = () => {
+        clearTimeout(timeoutTimer);
+        if (pollTimer) {
+          clearTimeout(pollTimer);
+        }
+      };
+
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimers();
+        callback();
+      };
+
+      const scheduleNextPoll = () => {
+        if (settled) {
+          return;
+        }
+
+        pollTimer = setTimeout(() => {
+          void pollOnce();
+        }, intervalMs);
+      };
+
+      const timeoutTimer = setTimeout(() => {
+        settle(() => {
+          reject(
+            new TransactionTimeoutError(
+              `Timed out waiting for transaction ${hash} after ${timeoutMs}ms`
+            )
+          );
+        });
+      }, timeoutMs);
+
+      const pollOnce = async () => {
+        try {
+          const res = await this.getTransaction(hash);
+          if (settled) {
+            return;
+          }
+
+          const parsed = parseTransactionPollResult(res);
+          if (parsed.status === "SUCCESS" || parsed.status === "FAILED") {
+            settle(() => resolve(parsed));
+            return;
+          }
+
+          scheduleNextPoll();
+        } catch (error) {
+          if (settled) {
+            return;
+          }
+
+          settle(() => reject(error));
+        }
+      };
+
+      void pollOnce();
+    });
   }
 
   private applyFeeBuffer(tx: Transaction): Transaction {
@@ -504,4 +569,41 @@ function toFraction(multiplier: number): { numerator: bigint; denominator: bigin
     numerator,
     denominator: denominator === BigInt(0) ? BigInt(1) : denominator
   };
+}
+
+function validatePollingInterval(value: number, fieldName: string, allowZero: boolean): void {
+  const valid = Number.isFinite(value) && (allowZero ? value >= 0 : value > 0);
+  if (!valid) {
+    throw new ValidationError(`${fieldName} must be a finite ${allowZero ? "non-negative" : "positive"} number`);
+  }
+}
+
+function parseTransactionPollResult(response: unknown): TransactionPollResult {
+  const record = isRecord(response) ? response : {};
+  const status = typeof record.status === "string" ? record.status : "UNKNOWN";
+
+  return {
+    ...record,
+    status,
+    ledger: normalizeLedger(record.ledger)
+  };
+}
+
+function normalizeLedger(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+}
+
+function isRecord(value: unknown): value is TransactionResponseRecord {
+  return typeof value === "object" && value !== null;
 }

--- a/src/errors/axionveraError.ts
+++ b/src/errors/axionveraError.ts
@@ -53,6 +53,8 @@ export class ContractError extends AxionveraError { }
 
 export class TimeoutError extends AxionveraError { }
 
+export class TransactionTimeoutError extends TimeoutError { }
+
 export class InsufficientFundsError extends AxionveraError { }
 
 export class InvalidSignatureError extends AxionveraError { }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
     RpcError,
     ContractError,
     TimeoutError,
+    TransactionTimeoutError,
     InsufficientFundsError,
     InvalidSignatureError,
     SimulationError,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,8 @@ export type { WalletConnector } from './wallet/walletConnector';
 // Utils
 export { ConcurrencyQueue, createConcurrencyControlledClient } from './utils/concurrencyQueue';
 export { retry, createHttpClientWithRetry } from './utils/httpInterceptor';
-export { buildContractCallOperation, buildContractCallTransaction, buildBaseTransaction, toScVal } from './utils/transactionBuilder';
-export type { BuildBaseTransactionParams } from './utils/transactionBuilder';
+export { buildContractCallOperation, buildContractCallTransaction, buildBaseTransaction, bumpTransactionFee, toScVal } from './utils/transactionBuilder';
+export type { BuildBaseTransactionParams, BumpTransactionFeeOptions } from './utils/transactionBuilder';
 export { getDefaultRpcUrl, getNetworkPassphrase, resolveNetworkConfig } from './utils/networkConfig';
 export { generateTransactionURI, generatePayURI } from './utils/sep7';
 

--- a/src/utils/transactionBuilder.ts
+++ b/src/utils/transactionBuilder.ts
@@ -1,6 +1,7 @@
 import {
   Account,
   Address,
+  FeeBumpTransaction,
   Contract,
   Transaction,
   TransactionBuilder,
@@ -129,6 +130,16 @@ export type BuildBaseTransactionParams = {
 };
 
 /**
+ * Options for wrapping a signed transaction in a fee bump envelope.
+ */
+export type BumpTransactionFeeOptions = {
+  /** The public key of the account sponsoring the higher fee */
+  feeSource: string;
+  /** The network passphrase used to parse and rebuild the transaction */
+  networkPassphrase: string;
+};
+
+/**
  * Builds a base transaction that can be extended with additional operations.
  * This is useful for composing multiple contract calls into a single transaction.
  * 
@@ -164,4 +175,54 @@ export function buildBaseTransaction(
   builder.setTimeout(timeoutInSeconds);
 
   return builder;
+}
+
+/**
+ * Wraps a signed transaction in an unsigned fee bump envelope.
+ *
+ * The returned XDR preserves the original user signature on the inner
+ * transaction. Only the outer fee bump envelope still needs to be signed
+ * by the sponsoring account before submission.
+ *
+ * @param signedXdr - The already-signed inner transaction XDR
+ * @param newBaseFee - The replacement base fee in stroops
+ * @param options - Fee bump configuration
+ * @returns The unsigned fee bump transaction XDR
+ */
+export function bumpTransactionFee(
+  signedXdr: string,
+  newBaseFee: number,
+  options: BumpTransactionFeeOptions
+): string {
+  if (!signedXdr) {
+    throw new Error("signedXdr is required");
+  }
+
+  if (!Number.isInteger(newBaseFee) || newBaseFee <= 0) {
+    throw new Error("newBaseFee must be a positive integer");
+  }
+
+  if (!options.feeSource) {
+    throw new Error("feeSource is required");
+  }
+
+  const innerTransaction = TransactionBuilder.fromXDR(
+    signedXdr,
+    options.networkPassphrase
+  );
+
+  if (innerTransaction instanceof FeeBumpTransaction) {
+    throw new Error("signedXdr must be a signed inner transaction, not an existing fee bump transaction");
+  }
+
+  if (innerTransaction.signatures.length === 0) {
+    throw new Error("signedXdr must include at least one signature before applying a fee bump");
+  }
+
+  return TransactionBuilder.buildFeeBumpTransaction(
+    options.feeSource,
+    newBaseFee.toString(),
+    innerTransaction,
+    options.networkPassphrase
+  ).toXDR();
 }

--- a/tests/errorClasses.test.ts
+++ b/tests/errorClasses.test.ts
@@ -8,6 +8,7 @@ import {
   RpcError,
   ContractError,
   TimeoutError,
+  TransactionTimeoutError,
   InsufficientFundsError,
   InvalidSignatureError,
   SimulationError,
@@ -114,6 +115,14 @@ describe('New error classes', () => {
     expect(error).toBeInstanceOf(AxionveraError);
     expect(error).toBeInstanceOf(TimeoutError);
     expect(error.message).toBe('Operation timed out');
+  });
+
+  it('TransactionTimeoutError extends TimeoutError', () => {
+    const error = new TransactionTimeoutError('Transaction polling timed out');
+    expect(error).toBeInstanceOf(AxionveraError);
+    expect(error).toBeInstanceOf(TimeoutError);
+    expect(error).toBeInstanceOf(TransactionTimeoutError);
+    expect(error.message).toBe('Transaction polling timed out');
   });
 
   it('InsufficientFundsError extends AxionveraError', () => {

--- a/tests/stellarClient.fee-buffer.test.ts
+++ b/tests/stellarClient.fee-buffer.test.ts
@@ -1,0 +1,115 @@
+import { Networks, rpc, SorobanDataBuilder, TransactionBuilder } from "@stellar/stellar-sdk";
+import { StellarClient } from "../src/client/stellarClient";
+import { ValidationError } from "../src/errors/axionveraError";
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: jest.fn().mockImplementation(() => ({
+        simulateTransaction: jest.fn(),
+        getHealth: jest.fn(),
+        getNetwork: jest.fn(),
+        getLatestLedger: jest.fn(),
+        getAccount: jest.fn(),
+        prepareTransaction: jest.fn(),
+        sendTransaction: jest.fn(),
+        getTransaction: jest.fn(),
+      })),
+    },
+  };
+});
+
+describe("StellarClient fee buffering", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("buffers Soroban resource limits and fees during transaction preparation", async () => {
+    const client = new StellarClient({ network: "testnet", feeBufferMultiplier: 1.15 });
+    const mockRpc = client.rpc as any;
+    const simulation = { id: "simulation" };
+    const sorobanData = new SorobanDataBuilder()
+      .setResources(1000, 2000, 3000)
+      .setResourceFee("2000")
+      .build();
+
+    const assembledTx = {
+      fee: "2100",
+      networkPassphrase: Networks.TESTNET,
+      toEnvelope: () => ({
+        v1: () => ({
+          tx: () => ({
+            ext: () => ({
+              value: () => sorobanData
+            })
+          })
+        })
+      })
+    } as any;
+
+    const bufferedTx = { id: "buffered" } as any;
+    let cloneOptions: any;
+
+    mockRpc.simulateTransaction.mockResolvedValue(simulation);
+    jest.spyOn(rpc, "assembleTransaction").mockReturnValue({
+      build: () => assembledTx
+    } as any);
+    jest.spyOn(TransactionBuilder, "cloneFrom").mockImplementation((_tx, options) => {
+      cloneOptions = options;
+      return {
+        build: () => bufferedTx
+      } as any;
+    });
+
+    const result = await client.prepareTransaction({ id: "raw-tx" } as any);
+
+    expect(result).toBe(bufferedTx);
+    expect(mockRpc.simulateTransaction).toHaveBeenCalledTimes(1);
+    expect(cloneOptions.fee).toBe("115");
+    expect(cloneOptions.sorobanData.resourceFee().toBigInt()).toBe(BigInt(2300));
+    expect(cloneOptions.sorobanData.resources().instructions()).toBe(1150);
+    expect(cloneOptions.sorobanData.resources().diskReadBytes()).toBe(2300);
+    expect(cloneOptions.sorobanData.resources().writeBytes()).toBe(3450);
+  });
+
+  it("throws when the buffered fee exceeds maxFeeLimit", async () => {
+    const client = new StellarClient({
+      network: "testnet",
+      feeBufferMultiplier: 1.15,
+      maxFeeLimit: 2300
+    });
+    const mockRpc = client.rpc as any;
+    const sorobanData = new SorobanDataBuilder()
+      .setResources(1000, 2000, 3000)
+      .setResourceFee("2000")
+      .build();
+
+    const assembledTx = {
+      fee: "2100",
+      networkPassphrase: Networks.TESTNET,
+      toEnvelope: () => ({
+        v1: () => ({
+          tx: () => ({
+            ext: () => ({
+              value: () => sorobanData
+            })
+          })
+        })
+      })
+    } as any;
+
+    mockRpc.simulateTransaction.mockResolvedValue({ id: "simulation" });
+    jest.spyOn(rpc, "assembleTransaction").mockReturnValue({
+      build: () => assembledTx
+    } as any);
+
+    const preparedPromise = client.prepareTransaction({ id: "raw-tx" } as any);
+
+    await expect(preparedPromise).rejects.toThrow(ValidationError);
+    await expect(preparedPromise).rejects.toThrow("Buffered fee (2415) exceeds maxFeeLimit (2300)");
+  });
+});

--- a/tests/stellarClient.polling.test.ts
+++ b/tests/stellarClient.polling.test.ts
@@ -1,0 +1,88 @@
+import { rpc } from '@stellar/stellar-sdk';
+import { StellarClient } from '../src/client/stellarClient';
+import { TransactionTimeoutError } from '../src/errors/axionveraError';
+
+jest.mock('@stellar/stellar-sdk');
+const mockedRpc = rpc as jest.Mocked<typeof rpc>;
+
+describe('StellarClient transaction polling', () => {
+  let mockServer: {
+    getTransaction: jest.Mock;
+  };
+  let client: StellarClient;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+
+    mockServer = {
+      getTransaction: jest.fn()
+    };
+
+    mockedRpc.Server = jest.fn().mockImplementation(() => mockServer as any);
+    client = new StellarClient();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns the final SUCCESS result with the included ledger', async () => {
+    mockServer.getTransaction
+      .mockResolvedValueOnce({ status: 'NOT_FOUND' })
+      .mockResolvedValueOnce({ status: 'SUCCESS', ledger: '12345', hash: 'tx-success' });
+
+    const resultPromise = client.pollTransaction('tx-success', {
+      timeoutMs: 60_000,
+      intervalMs: 3_000
+    });
+
+    await Promise.resolve();
+    expect(mockServer.getTransaction).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(2_999);
+    expect(mockServer.getTransaction).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'SUCCESS',
+      ledger: 12345,
+      hash: 'tx-success'
+    });
+    expect(mockServer.getTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the final FAILED result instead of timing out', async () => {
+    mockServer.getTransaction
+      .mockResolvedValueOnce({ status: 'PENDING' })
+      .mockResolvedValueOnce({ status: 'FAILED', ledger: 777, hash: 'tx-failed' });
+
+    const resultPromise = client.pollTransaction('tx-failed', {
+      timeoutMs: 60_000,
+      intervalMs: 3_000
+    });
+
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(3_000);
+
+    await expect(resultPromise).resolves.toMatchObject({
+      status: 'FAILED',
+      ledger: 777,
+      hash: 'tx-failed'
+    });
+  });
+
+  it('throws TransactionTimeoutError when a final status is never reached', async () => {
+    mockServer.getTransaction.mockResolvedValue({ status: 'NOT_FOUND' });
+
+    const resultPromise = client.pollTransaction('tx-timeout', {
+      timeoutMs: 60_000,
+      intervalMs: 3_000
+    });
+    const rejection = expect(resultPromise).rejects.toBeInstanceOf(TransactionTimeoutError);
+
+    await Promise.resolve();
+    await jest.advanceTimersByTimeAsync(60_000);
+    await rejection;
+  });
+});

--- a/tests/stellarClient.retry.test.ts
+++ b/tests/stellarClient.retry.test.ts
@@ -189,7 +189,7 @@ describe('StellarClient Retry Functionality', () => {
 
     it('should not retry prepareTransaction', async () => {
       const error = { response: { status: 500 } };
-      mockServer.prepareTransaction.mockRejectedValue(error);
+      mockServer.simulateTransaction.mockRejectedValue(error);
 
       let thrown: unknown;
       try {
@@ -200,7 +200,7 @@ describe('StellarClient Retry Functionality', () => {
 
       expect(thrown).toBeInstanceOf(NetworkError);
       expect(thrown).toMatchObject({ statusCode: 500 });
-      expect(mockServer.prepareTransaction).toHaveBeenCalledTimes(1);
+      expect(mockServer.simulateTransaction).toHaveBeenCalledTimes(1);
     });
 
     it('should not retry sendTransaction', async () => {

--- a/tests/transactionBuilder.test.ts
+++ b/tests/transactionBuilder.test.ts
@@ -1,5 +1,17 @@
-import { Account, Keypair, Address } from "@stellar/stellar-sdk";
-import { buildContractCallOperation, buildContractCallTransaction, toScVal } from "../src/utils/transactionBuilder";
+import {
+  Account,
+  Address,
+  FeeBumpTransaction,
+  Keypair,
+  Networks,
+  TransactionBuilder
+} from "@stellar/stellar-sdk";
+import {
+  buildContractCallOperation,
+  buildContractCallTransaction,
+  bumpTransactionFee,
+  toScVal
+} from "../src/utils/transactionBuilder";
 
 describe("transactionBuilder utils", () => {
   const account = new Account(Keypair.random().publicKey(), "1");
@@ -81,5 +93,51 @@ describe("transactionBuilder utils", () => {
 
     expect(tx.operations.length).toBe(1);
     expect(tx.operations[0].body().switch()).toBe("invokeHostFunction");
+  });
+
+  test("bumpTransactionFee wraps a signed transaction in an unsigned fee bump envelope", () => {
+    const source = Keypair.random();
+    const sponsor = Keypair.random();
+    const innerTx = buildContractCallTransaction({
+      sourceAccount: new Account(source.publicKey(), "1"),
+      networkPassphrase: Networks.TESTNET,
+      contractId: "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef",
+      method: "deposit",
+      args: [1]
+    });
+
+    innerTx.sign(source);
+
+    const feeBumpXdr = bumpTransactionFee(innerTx.toXDR(), 200, {
+      feeSource: sponsor.publicKey(),
+      networkPassphrase: Networks.TESTNET
+    });
+
+    const parsed = TransactionBuilder.fromXDR(feeBumpXdr, Networks.TESTNET);
+    expect(parsed).toBeInstanceOf(FeeBumpTransaction);
+
+    const feeBumpTx = parsed as FeeBumpTransaction;
+    expect(feeBumpTx.feeSource).toBe(sponsor.publicKey());
+    expect(feeBumpTx.signatures).toHaveLength(0);
+    expect(feeBumpTx.innerTransaction.signatures).toHaveLength(1);
+    expect(feeBumpTx.innerTransaction.toXDR()).toBe(innerTx.toXDR());
+  });
+
+  test("bumpTransactionFee rejects unsigned inner transactions", () => {
+    const sponsor = Keypair.random();
+    const innerTx = buildContractCallTransaction({
+      sourceAccount: new Account(Keypair.random().publicKey(), "1"),
+      networkPassphrase: Networks.TESTNET,
+      contractId: "abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef",
+      method: "deposit",
+      args: [1]
+    });
+
+    expect(() =>
+      bumpTransactionFee(innerTx.toXDR(), 200, {
+        feeSource: sponsor.publicKey(),
+        networkPassphrase: Networks.TESTNET
+      })
+    ).toThrow("signedXdr must include at least one signature");
   });
 });

--- a/tests/transactionSigner.test.ts
+++ b/tests/transactionSigner.test.ts
@@ -1,7 +1,7 @@
 import { TransactionSigner, SimulationResult, TransactionResult } from '../src/transaction';
 import { StellarClient } from '../src/client/stellarClient';
 import { LocalKeypairWalletConnector } from '../src/wallet/localKeypairWalletConnector';
-import { Keypair } from '@stellar/stellar-sdk';
+import { Account, FeeBumpTransaction, Keypair, Networks, TransactionBuilder } from '@stellar/stellar-sdk';
 
 // Mock dependencies for testing
 jest.mock('../src/client/stellarClient');
@@ -194,21 +194,40 @@ describe('TransactionSigner', () => {
 
   describe('createFeeBumpTransaction', () => {
     it('should create and sign a fee bump transaction', async () => {
-      const mockFeeSourceAccount = {
-        accountId: 'GFEE123456789',
-        sequence: '1'
-      };
+      const source = Keypair.random();
+      const sponsor = Keypair.random();
+      const innerTransaction = new TransactionBuilder(
+        new Account(source.publicKey(), '1'),
+        {
+          fee: '100',
+          networkPassphrase: Networks.TESTNET
+        }
+      )
+        .setTimeout(30)
+        .build();
 
-      mockClient.rpc!.getAccount = jest.fn().mockResolvedValue(mockFeeSourceAccount);
+      innerTransaction.sign(source);
 
       const result = await transactionSigner.createFeeBumpTransaction({
-        innerTransaction: 'inner-xdr',
-        feeSource: 'GFEE123456789',
+        innerTransaction: innerTransaction.toXDR(),
+        feeSource: sponsor.publicKey(),
         baseFee: 100
       });
 
-      expect(result).toBeDefined();
-      expect(mockWallet.signTransaction).toHaveBeenCalled();
+      expect(result).toBe('signed-xdr');
+      expect(mockWallet.signTransaction).toHaveBeenCalledWith(
+        expect.any(String),
+        Networks.TESTNET
+      );
+
+      const [feeBumpEnvelopeXdr] = mockWallet.signTransaction.mock.calls[0];
+      const parsed = TransactionBuilder.fromXDR(feeBumpEnvelopeXdr, Networks.TESTNET);
+      expect(parsed).toBeInstanceOf(FeeBumpTransaction);
+
+      const feeBumpTx = parsed as FeeBumpTransaction;
+      expect(feeBumpTx.feeSource).toBe(sponsor.publicKey());
+      expect(feeBumpTx.signatures).toHaveLength(0);
+      expect(feeBumpTx.innerTransaction.signatures).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
# Description

This PR introduces major transaction reliability improvements by addressing fee estimation buffers, transaction polling precision, and transaction recovery mechanisms (fee bumps). 

Closes #83
Closes #92
Closes #100

## Changes Included

### Automatic Fee Estimation & Buffering (#83)
* **Configurable Buffers:** Introduced `feeBufferMultiplier` (defaults to `1.15` / +15%) in `StellarClient` options to pad limits against network congestion.
* **Smart Preparation:** Updated `prepareTransaction` to simulate first, then safely scale CPU instructions, RAM usage, base fees, and resource fees using the `SorobanDataBuilder`.
* **Safety Caps:** Added a `maxFeeLimit` developer option that throws a `ValidationError` to prevent unintentional wallet draining if the simulated or buffered fee exceeds the threshold.

### Precise Transaction Polling (#92)
* **Non-blocking Loop:** Refactored `pollTransaction` to utilize `setTimeout` scheduling rather than blocking `while` loops to keep the event loop unblocked.
* **Configurable Timeouts:** Added support for `timeoutMs` and `intervalMs` parameters.
* **Strict Resolution:** The polling now waits explicitly for `SUCCESS` or `FAILED` statuses. If it times out beforehand, it correctly throws a dedicated `TransactionTimeoutError`.
* **Ledger Details:** The method now parses and returns the final transaction result, including normalizing the ledger number where the transaction was included.

### Fee Bump Transaction Recovery (#100)
* **New Utility:** Added `bumpTransactionFee(signedXdr, newBaseFee, options)` to `transactionBuilder`.
* **Sponsor Workflow:** Wraps an already user-signed inner transaction in an unsigned fee bump envelope via the SDK's `FeeBumpTransaction` builder. This allows a backend sponsor wallet to pay for the fee bump without needing the original user to re-sign.
* **DX Documentation:** Comprehensively documented this sponsor-signing workflow in the `README` and usage guides for enterprise dApp integrations.

## Technical Notes
* All changes have been appropriately mirrored across both the root `src` and `packages/core/src` directories.
* Added extensive unit testing for the fee-buffering logic, precise timeout/polling states, and fee-bump XDR generation.