### PR TITLE
feat(client): respect Retry-After header for 429 responses (#139)

### DIFF
--- a/RETRY_FEATURE.md
+++ b/RETRY_FEATURE.md
@@ -6,6 +6,7 @@ This feature adds automatic retry functionality to the Axionvera SDK to make it 
 
 - **Automatic Retries**: Configurable retry logic for failed HTTP requests
 - **Exponential Backoff**: Implements exponential backoff algorithm (1s, 2s, 4s, etc.)
+- **Retry-After Support**: Respects the standard `Retry-After` header on 429 (Too Many Requests) responses
 - **Idempotent Operations Only**: Only retries safe operations (GET, PUT)
 - **Configurable**: Full control over retry behavior via configuration
 - **Status Code Filtering**: Retries on specific HTTP status codes (429, 5xx)
@@ -70,11 +71,16 @@ const client = new StellarClient({
 
 ## Exponential Backoff Algorithm
 
-The delay between retries follows this pattern:
-- Attempt 1: 1 second (1000ms)
-- Attempt 2: 2 seconds (2000ms)
-- Attempt 3: 4 seconds (4000ms)
-- Attempt 4: 8 seconds (8000ms, capped at maxDelayMs)
+The delay between retries follows this logic:
+
+1. **Priority Header**: If a `429 Too Many Requests` response includes a `Retry-After` header, the SDK pauses execution for the exact duration specified (supporting both seconds and HTTP-date formats), capped at `maxDelayMs` for safety.
+2. **Fallback Backoff**: If the header is missing or for other status codes, it uses exponential backoff:
+   - Attempt 1: 1 second (1000ms)
+   - Attempt 2: 2 seconds (2000ms)
+   - Attempt 3: 4 seconds (4000ms)
+   - Attempt 4: 8 seconds (8000ms, capped at `maxDelayMs`)
+
+A 20% random jitter is applied to exponential backoff calculations to prevent "thundering herd" issues.
 
 ## Which Operations Are Retried?
 

--- a/packages/core/src/utils/httpInterceptor.ts
+++ b/packages/core/src/utils/httpInterceptor.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse, AxiosError } from 'axios';
 import { getErrorStatusCode, toAxionveraError } from '../errors/axionveraError';
+import { Logger } from './logger';
 
 /**
  * Configuration for retry behavior.
@@ -28,10 +29,40 @@ export const DEFAULT_RETRY_CONFIG: RetryConfig = {
   retryableStatusCodes: [429, 500, 502, 503, 504]
 };
 
+// Internal logger instance
+const logger = new Logger('info');
+
 function calculateDelay(attemptNumber: number, baseDelayMs: number, maxDelayMs: number): number {
   const delay = baseDelayMs * Math.pow(2, attemptNumber - 1);
   const jitter = delay * 0.2 * (Math.random() - 0.5);
   return Math.min(delay + jitter, maxDelayMs);
+}
+
+/**
+ * Extracts the delay from the Retry-After header if present.
+ * Supports both decimal integer (seconds) and HTTP-date formats.
+ */
+function getRetryAfterDelay(error: unknown): number | undefined {
+  const headers = (error as any)?.response?.headers;
+  if (!headers) return undefined;
+
+  // Axios normalizes headers to lowercase
+  const retryAfter = headers['retry-after'];
+  if (!retryAfter) return undefined;
+
+  // Retry-After can be seconds (integer)
+  const seconds = parseInt(retryAfter, 10);
+  if (!isNaN(seconds)) {
+    return seconds * 1000;
+  }
+
+  // Or an HTTP-date
+  const date = Date.parse(retryAfter);
+  if (!isNaN(date)) {
+    return Math.max(0, date - Date.now());
+  }
+
+  return undefined;
 }
 
 function isRetryableRequest(config: AxiosRequestConfig, retryConfig: RetryConfig): boolean {
@@ -87,16 +118,21 @@ export function createHttpClientWithRetry(
 
       originalRequest._retryCount++;
 
-      const delayMs = calculateDelay(originalRequest._retryCount, config.baseDelayMs, config.maxDelayMs);
+      const statusCode = getErrorStatusCode(error);
+      const retryAfterDelay = getRetryAfterDelay(error);
+
+      // Use Retry-After if 429, but cap it at maxDelayMs for safety
+      const delayMs = (statusCode === 429 && retryAfterDelay !== undefined)
+        ? Math.min(retryAfterDelay, config.maxDelayMs)
+        : calculateDelay(originalRequest._retryCount, config.baseDelayMs, config.maxDelayMs);
       
-      console.log(JSON.stringify({
-        message: 'Retrying request',
+      logger.info('Retrying request', {
         attempt: originalRequest._retryCount,
         delay: delayMs,
         url: originalRequest.url,
         method: originalRequest.method,
-        error: error.message,
-      }));
+        error: error instanceof Error ? error.message : String(error),
+      });
 
       await delay(delayMs);
 
@@ -144,7 +180,13 @@ export async function retry<T>(
         throw toAxionveraError(error);
       }
 
-      const delayMs = calculateDelay(attempt, config.baseDelayMs, config.maxDelayMs);
+      const retryAfterDelay = getRetryAfterDelay(error);
+
+      // Use Retry-After if 429, but cap it at maxDelayMs for safety
+      const delayMs = (statusCode === 429 && retryAfterDelay !== undefined)
+        ? Math.min(retryAfterDelay, config.maxDelayMs)
+        : calculateDelay(attempt, config.baseDelayMs, config.maxDelayMs);
+
       await delay(delayMs);
     }
   }

--- a/tests/retryAfter.test.ts
+++ b/tests/retryAfter.test.ts
@@ -1,0 +1,83 @@
+import { createHttpClientWithRetry } from '../packages/core/src/utils/httpInterceptor';
+import { setupMswTest, overrideHandlers, rest } from '../src/index';
+
+describe('Retry-After Header Handling', () => {
+  // Uses the MSW suite to intercept network calls
+  setupMswTest();
+
+  const rpcUrl = 'https://soroban-testnet.stellar.org';
+  const client = createHttpClientWithRetry({
+    baseDelayMs: 100, // Shorten for faster tests
+    maxDelayMs: 5000
+  });
+
+  it('should respect Retry-After header with delta-seconds', async () => {
+    let attempts = 0;
+    const retrySeconds = 1;
+    
+    overrideHandlers(
+      rest.get(`${rpcUrl}/health`, (req, res, ctx) => {
+        attempts++;
+        if (attempts === 1) {
+          return res(
+            ctx.status(429),
+            ctx.set('Retry-After', retrySeconds.toString()),
+            ctx.json({ error: 'Too Many Requests' })
+          );
+        }
+        return res(ctx.json({ status: 'healthy' }));
+      })
+    );
+
+    const start = Date.now();
+    await client.get(`${rpcUrl}/health`);
+    const duration = Date.now() - start;
+
+    // Should wait at least the duration specified in the header
+    expect(duration).toBeGreaterThanOrEqual(retrySeconds * 1000);
+    expect(attempts).toBe(2);
+  });
+
+  it('should respect Retry-After header with HTTP-date', async () => {
+    let attempts = 0;
+    const waitMs = 1500;
+    const retryDate = new Date(Date.now() + waitMs).toUTCString();
+    
+    overrideHandlers(
+      rest.get(`${rpcUrl}/health`, (req, res, ctx) => {
+        attempts++;
+        if (attempts === 1) {
+          return res(
+            ctx.status(429),
+            ctx.set('Retry-After', retryDate),
+            ctx.json({ error: 'Too Many Requests' })
+          );
+        }
+        return res(ctx.json({ status: 'healthy' }));
+      })
+    );
+
+    const start = Date.now();
+    await client.get(`${rpcUrl}/health`);
+    const duration = Date.now() - start;
+
+    expect(duration).toBeGreaterThanOrEqual(waitMs);
+    expect(attempts).toBe(2);
+  });
+
+  it('should fall back to exponential backoff if Retry-After is missing', async () => {
+    let attempts = 0;
+    overrideHandlers(
+      rest.get(`${rpcUrl}/health`, (req, res, ctx) => {
+        attempts++;
+        if (attempts === 1) {
+          return res(ctx.status(429), ctx.json({ error: 'Too Many Requests' }));
+        }
+        return res(ctx.json({ status: 'healthy' }));
+      })
+    );
+
+    await client.get(`${rpcUrl}/health`);
+    expect(attempts).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #139

---

This PR addresses issue #139 by updating the SDK's retry logic to honor the server-provided Retry-After header when a 429 Too Many Requests error occurs. This ensures a more "polite" and efficient interaction with Soroban RPC nodes compared to generic backoff.

Key Changes:
Header Parsing: Implemented getRetryAfterDelay to support both RFC 9110 formats: delta-seconds (integers) and IMF-fixdate (HTTP-dates).
Safety Cap: Introduced a safety check to ensure that the server-suggested delay never exceeds the SDK's configured maxDelayMs, preventing potential indefinite hangs.
Consistent Implementation: Updated both the Axios interceptor and the standalone retry utility to share this logic.
Improved Logging: Replaced standard console output with the SDK's internal Logger for better traceability and redaction of sensitive request data.
Reliable Fallback: The SDK continues to use standard exponential backoff with jitter if the Retry-After header is missing or the status code is not 429.