### PR TITLE
Build Axionvera SDK CLI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,183 @@
+# Axionvera SDK CLI
+
+`axionvera-cli` is a command-line utility for interacting with Axionvera
+contracts and Stellar/Soroban networks. It can query balances, execute contract
+methods (read-only simulations or signed submissions), inspect network
+configuration, and generate TypeScript contract clients from WASM.
+
+The CLI talks to the network directly through `@stellar/stellar-sdk`, so it works
+as a standalone tool without any additional setup beyond installing the package.
+
+## Installation
+
+The CLI ships with `@axionvera/core` and is exposed as the `axionvera-cli` binary.
+
+```bash
+# Global install
+npm install -g @axionvera/core
+axionvera-cli --help
+
+# Or run on demand without installing
+npx --package @axionvera/core axionvera-cli --help
+```
+
+When working inside this repository you can run it directly:
+
+```bash
+node packages/core/bin/axionvera-cli.js --help
+```
+
+## Network configuration
+
+Every network-aware command (`network`, `balance`, `invoke`) resolves its target
+the same way, with the following precedence:
+
+1. Command-line flag
+2. Environment variable
+3. Built-in default (`testnet`)
+
+| Setting    | Flag          | Environment variable           |
+| ---------- | ------------- | ------------------------------ |
+| Network    | `--network`   | `AXIONVERA_NETWORK`            |
+| RPC URL    | `--rpc`       | `AXIONVERA_RPC_URL`            |
+| Horizon    | `--horizon`   | `AXIONVERA_HORIZON_URL`        |
+| Passphrase | `--passphrase`| `AXIONVERA_NETWORK_PASSPHRASE` |
+
+Supported networks: `testnet` (default), `futurenet`, `mainnet`.
+
+```bash
+# Inspect the resolved configuration and check RPC health
+axionvera-cli network
+axionvera-cli network --network mainnet --no-ping
+axionvera-cli network --json
+```
+
+## `balance` — query balances
+
+Without `--contract`, the command loads an account's classic balances (native
+XLM and trustlines) from Horizon. With `--contract`, it queries a Soroban token
+contract's `balance` method for the account via a read-only simulation.
+
+```bash
+# Classic (XLM + trustline) balances
+axionvera-cli balance GD5J...KUZ2V
+axionvera-cli balance GD5J...KUZ2V --network mainnet --json
+
+# Soroban token balance
+axionvera-cli balance GD5J...KUZ2V --contract CBIE...TOKEN
+```
+
+| Option            | Description                                            |
+| ----------------- | ------------------------------------------------------ |
+| `<account>`       | Stellar account public key (`G...`), required          |
+| `--contract <id>` | Query a Soroban token contract (`C...`) balance        |
+| `--network, -n`   | `testnet` \| `futurenet` \| `mainnet`                  |
+| `--rpc` / `--horizon` | Endpoint overrides                                 |
+| `--json`          | Print machine-readable JSON                            |
+
+## `invoke` — execute a contract method
+
+Builds a contract call, simulates it, and either prints the decoded return value
+(read-only) or — when `--source` is supplied — assembles, signs, submits, and
+polls the transaction to completion.
+
+```bash
+# Read-only call (no key required)
+axionvera-cli invoke CBIE...TOKEN balance --arg address:GD5J...KUZ2V
+
+# Signed write
+axionvera-cli invoke CBIE...TOKEN transfer \
+  --arg address:GFROM... \
+  --arg address:GTO... \
+  --arg i128:1000 \
+  --source SB... --network testnet
+```
+
+| Option            | Description                                                       |
+| ----------------- | ----------------------------------------------------------------- |
+| `<contractId>`    | Soroban contract id (`C...`), required                            |
+| `<method>`        | Contract method name, required                                    |
+| `--arg <value>`   | Method argument; repeatable, order preserved                      |
+| `--source <secret>` | Sign and submit with this secret key (`S...`)                   |
+| `--as <publicKey>`| Simulate as this account (read-only); defaults to a throwaway one |
+| `--fee <stroops>` | Base fee in stroops (default: 100)                                |
+| `--network, -n`   | `testnet` \| `futurenet` \| `mainnet`                             |
+| `--rpc`           | RPC endpoint override                                             |
+| `--yes, -y`       | Skip the mainnet write confirmation                               |
+| `--json`          | Print machine-readable JSON                                       |
+
+### Argument types
+
+Arguments may carry an explicit `type:value` prefix, or let the CLI infer the
+type. Inference rules: a valid Stellar address becomes an `Address`, a plain
+integer becomes `i128`, `true`/`false` becomes `bool`, and anything else becomes
+a `string`. Use an explicit prefix when the inference is wrong (for example a
+`symbol`, a `u32`, or a numeric string that should be a `string`).
+
+Supported prefixes:
+
+```
+address | account | contract   # G... or C... -> Address
+bool                            # true / false
+u32 | i32                       # 32-bit integers
+u64 | i64 | u128 | i128 | u256 | i256   # big integers
+symbol                          # Soroban symbol
+string                          # UTF-8 string
+bytes                           # hex-encoded byte string
+```
+
+Examples:
+
+```bash
+--arg i128:1000
+--arg address:GD5J...KUZ2V
+--arg symbol:transfer
+--arg bool:true
+--arg u32:7
+--arg string:42        # the literal string "42", not a number
+```
+
+### Read vs. write
+
+- **Read-only** (no `--source`): the call is simulated and the decoded return
+  value is printed. No account funds or signing are required.
+- **Write** (`--source <secret>`): the simulated transaction is assembled with
+  the correct resource fees, signed, submitted, and polled. On `mainnet` the CLI
+  refuses to submit unless `--yes` is also passed.
+
+> Security note: passing a secret key on the command line can leak it into your
+> shell history and process list. Prefer short-lived keys for testing, and never
+> use a mainnet secret on an untrusted machine.
+
+## `codegen` — generate a TypeScript contract client
+
+Generates a typed client class from a compiled Soroban contract WASM.
+
+```bash
+axionvera-cli codegen ./target/wasm32-unknown-unknown/release/my_token.wasm \
+  --out ./src/contracts \
+  --name TokenContract
+```
+
+| Option            | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| `<contract.wasm>` | Path to the compiled contract WASM, required         |
+| `--out, -o <dir>` | Output directory (default: current directory)        |
+| `--name, -n <name>` | Class name (default: derived from the filename)    |
+| `--import <path>` | Import path for `@axionvera/core`                    |
+
+## Exit codes
+
+- `0` — success
+- `1` — usage error, validation failure, or a failed network/contract operation
+
+## Examples cheat sheet
+
+```bash
+axionvera-cli network --network testnet
+axionvera-cli balance GD5J...KUZ2V
+axionvera-cli balance GD5J...KUZ2V --contract CBIE...TOKEN
+axionvera-cli invoke CBIE...TOKEN balance --arg address:GD5J...KUZ2V
+axionvera-cli invoke CBIE...TOKEN transfer --arg address:GA... --arg address:GB... --arg i128:1000 --source SB...
+axionvera-cli codegen ./my_token.wasm --name TokenContract
+```

--- a/packages/core/bin/axionvera-cli.js
+++ b/packages/core/bin/axionvera-cli.js
@@ -1,163 +1,83 @@
 #!/usr/bin/env node
-// axionvera-cli — Soroban contract code generator
-// Usage: axionvera-cli codegen <contract.wasm> [options]
+// axionvera-cli — command-line utility for interacting with Axionvera
+// contracts and Stellar/Soroban networks.
 //
-// Options:
-//   --out, -o <dir>       Output directory (default: current directory)
-//   --name, -n <name>     Class name (default: derived from wasm filename)
-//   --import <path>       Import path for @axionvera/core (default: "@axionvera/core")
-//   --help, -h            Show this help message
+// Commands:
+//   network   Show the resolved network configuration and RPC health
+//   balance   Query classic or Soroban token balances for an account
+//   invoke    Simulate or submit a contract method call
+//   codegen   Generate a TypeScript contract client from a WASM spec
+//
+// Run `axionvera-cli <command> --help` for command-specific options.
 
 "use strict";
 
-const path = require("path");
-const fs = require("fs");
+const pkg = require("../package.json");
 
-// ─── Argument parsing ─────────────────────────────────────────────────────────
-
-const args = process.argv.slice(2);
+const COMMANDS = {
+  network: () => require("./commands/network"),
+  balance: () => require("./commands/balance"),
+  invoke: () => require("./commands/invoke"),
+  codegen: () => require("./commands/codegen"),
+};
 
 function printHelp() {
   console.log(`
-axionvera-cli — Soroban contract TypeScript code generator
+axionvera-cli — interact with Axionvera contracts and Stellar/Soroban networks
 
 Usage:
-  axionvera-cli codegen <contract.wasm> [options]
+  axionvera-cli <command> [options]
 
-Options:
-  --out, -o <dir>     Output directory (default: current directory)
-  --name, -n <name>   Class name (default: derived from wasm filename)
-  --import <path>     Import path for @axionvera/core (default: "@axionvera/core")
-  --help, -h          Show this help message
+Commands:
+  network   Show the resolved network configuration and RPC health
+  balance   Query classic or Soroban token balances for an account
+  invoke    Simulate or submit a contract method call
+  codegen   Generate a TypeScript contract client from a WASM spec
 
-Example:
-  axionvera-cli codegen ./target/wasm32-unknown-unknown/release/my_token.wasm \\
-    --out ./src/contracts \\
-    --name TokenContract
+Global:
+  --help, -h       Show this help message
+  --version, -v    Show the CLI version
+
+Network selection (supported by network/balance/invoke):
+  --network, -n <name>   testnet | futurenet | mainnet (default: testnet)
+  --rpc <url>            Override the Soroban RPC URL
+  --horizon <url>        Override the Horizon URL
+
+Environment variables:
+  AXIONVERA_NETWORK, AXIONVERA_RPC_URL, AXIONVERA_HORIZON_URL,
+  AXIONVERA_NETWORK_PASSPHRASE
+
+Run "axionvera-cli <command> --help" for command-specific options.
 `);
 }
 
-if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
-  printHelp();
-  process.exit(0);
-}
+async function main() {
+  const argv = process.argv.slice(2);
 
-const command = args[0];
+  if (argv.length === 0 || argv[0] === "--help" || argv[0] === "-h") {
+    printHelp();
+    process.exit(0);
+  }
 
-if (command !== "codegen") {
-  console.error(`Unknown command: ${command}. Run with --help for usage.`);
-  process.exit(1);
-}
+  if (argv[0] === "--version" || argv[0] === "-v") {
+    console.log(pkg.version);
+    process.exit(0);
+  }
 
-// Parse remaining flags
-let wasmPath = null;
-let outDir = process.cwd();
-let className = null;
-let coreImport = "@axionvera/core";
+  const command = argv[0];
+  const loader = COMMANDS[command];
 
-for (let i = 1; i < args.length; i++) {
-  const arg = args[i];
-  if (arg === "--out" || arg === "-o") {
-    outDir = args[++i];
-  } else if (arg === "--name" || arg === "-n") {
-    className = args[++i];
-  } else if (arg === "--import") {
-    coreImport = args[++i];
-  } else if (!arg.startsWith("-")) {
-    wasmPath = arg;
-  } else {
-    console.error(`Unknown option: ${arg}. Run with --help for usage.`);
+  if (!loader) {
+    console.error(`Unknown command: ${command}. Run with --help for usage.`);
+    process.exit(1);
+  }
+
+  try {
+    await loader().run(argv.slice(1));
+  } catch (err) {
+    console.error(`Error: ${err && err.message ? err.message : err}`);
     process.exit(1);
   }
 }
 
-if (!wasmPath) {
-  console.error("Error: <contract.wasm> path is required.");
-  printHelp();
-  process.exit(1);
-}
-
-// Resolve paths
-const resolvedWasm = path.resolve(process.cwd(), wasmPath);
-
-if (!fs.existsSync(resolvedWasm)) {
-  console.error(`Error: WASM file not found: ${resolvedWasm}`);
-  process.exit(1);
-}
-
-// Derive class name from filename if not provided
-if (!className) {
-  const base = path.basename(resolvedWasm, ".wasm");
-  // snake_case → PascalCase + "Contract" suffix
-  className = base
-    .replace(/[-_](.)/g, (_, c) => c.toUpperCase())
-    .replace(/^(.)/, (_, c) => c.toUpperCase());
-  if (!className.toLowerCase().endsWith("contract")) {
-    className += "Contract";
-  }
-}
-
-// ─── Run codegen ──────────────────────────────────────────────────────────────
-
-// We require the compiled dist files. If running from source (ts-node / tests),
-// the TypeScript files are loaded directly via ts-node's require hook.
-// In production (after `npm run build`), the dist/ CJS files are used.
-function requireCodegen() {
-  // Try dist first (production)
-  const distParser = path.join(__dirname, "../dist/codegen/wasmParser.js");
-  const distGenerator = path.join(__dirname, "../dist/codegen/generator.js");
-  if (fs.existsSync(distParser) && fs.existsSync(distGenerator)) {
-    return {
-      parseWasm: require(distParser).parseWasm,
-      generateContractClass: require(distGenerator).generateContractClass,
-    };
-  }
-  // Fallback: try src (ts-node environment)
-  const srcParser = path.join(__dirname, "../src/codegen/wasmParser.ts");
-  if (fs.existsSync(srcParser)) {
-    // Register ts-node if available
-    try { require("ts-node/register"); } catch (_) {}
-    return {
-      parseWasm: require(srcParser).parseWasm,
-      generateContractClass: require(path.join(__dirname, "../src/codegen/generator.ts")).generateContractClass,
-    };
-  }
-  throw new Error(
-    "Could not locate codegen modules. Run `npm run build` in packages/core first."
-  );
-}
-
-let parseWasm, generateContractClass;
-try {
-  ({ parseWasm, generateContractClass } = requireCodegen());
-} catch (err) {
-  console.error(`Error loading codegen modules: ${err.message}`);
-  process.exit(1);
-}
-
-console.log(`Parsing WASM spec from: ${resolvedWasm}`);
-
-let spec;
-try {
-  spec = parseWasm(resolvedWasm);
-} catch (err) {
-  console.error(`Error parsing WASM: ${err.message}`);
-  process.exit(1);
-}
-
-console.log(
-  `Found ${spec.functions.length} function(s), ` +
-  `${spec.structs.length} struct(s), ` +
-  `${spec.enums.length} enum(s).`
-);
-
-const source = generateContractClass(spec, className, coreImport);
-
-// Write output file
-const resolvedOut = path.resolve(process.cwd(), outDir);
-fs.mkdirSync(resolvedOut, { recursive: true });
-
-const outFile = path.join(resolvedOut, `${className}.ts`);
-fs.writeFileSync(outFile, source, "utf8");
-
-console.log(`Generated: ${outFile}`);
+main();

--- a/packages/core/bin/commands/balance.js
+++ b/packages/core/bin/commands/balance.js
@@ -1,0 +1,148 @@
+"use strict";
+
+// axionvera-cli balance — query account balances.
+//
+// Without --contract it loads classic balances (XLM + trustlines) from Horizon.
+// With --contract <tokenId> it queries a Soroban token contract's `balance`
+// method for the account via a read-only simulation.
+
+const {
+  resolveNetwork,
+  parseArgs,
+  isStellarAddress,
+  printJson,
+  sdk,
+  fail,
+} = require("./shared");
+
+const HELP = `
+axionvera-cli balance — query account balances
+
+Usage:
+  axionvera-cli balance <account> [options]
+
+Arguments:
+  <account>              Stellar account public key (G...)
+
+Options:
+  --contract <id>        Query a Soroban token contract balance (C...) instead
+                         of classic Horizon balances
+  --network, -n <name>   testnet | futurenet | mainnet (default: testnet)
+  --rpc <url>            Override the Soroban RPC URL
+  --horizon <url>        Override the Horizon URL
+  --json                 Print result as JSON
+  --help, -h             Show this help message
+
+Examples:
+  axionvera-cli balance GD5J...KUZ2V
+  axionvera-cli balance GD5J...KUZ2V --network mainnet
+  axionvera-cli balance GD5J...KUZ2V --contract CBIE...TOKEN
+`;
+
+async function run(argv) {
+  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) {
+    console.log(HELP);
+    return;
+  }
+
+  const { flags, positionals } = parseArgs(argv, {
+    aliases: { "-n": "network" },
+    booleans: ["json"],
+  });
+
+  const account = positionals[0];
+  if (!account) fail("An <account> public key is required.");
+  if (!sdk.StrKey.isValidEd25519PublicKey(account)) {
+    fail(`"${account}" is not a valid Stellar account public key (expected G...).`);
+  }
+
+  const config = resolveNetwork(flags);
+
+  if (flags.contract) {
+    await contractBalance(account, flags.contract, config, flags.json);
+  } else {
+    await classicBalance(account, config, flags.json);
+  }
+}
+
+async function classicBalance(account, config, json) {
+  const server = new sdk.Horizon.Server(config.horizonUrl, {
+    allowHttp: config.horizonUrl.startsWith("http://"),
+  });
+
+  let loaded;
+  try {
+    loaded = await server.loadAccount(account);
+  } catch (err) {
+    if (err && err.response && err.response.status === 404) {
+      fail(`Account not found on ${config.network}: ${account}`);
+    }
+    fail(`Failed to load account: ${err.message}`);
+  }
+
+  const balances = loaded.balances.map((b) => ({
+    asset:
+      b.asset_type === "native"
+        ? "XLM"
+        : `${b.asset_code}:${b.asset_issuer}`,
+    balance: b.balance,
+  }));
+
+  if (json) {
+    printJson({ account, network: config.network, balances });
+    return;
+  }
+
+  console.log(`Account: ${account} (${config.network})`);
+  for (const b of balances) {
+    console.log(`  ${b.balance.padStart(20)}  ${b.asset}`);
+  }
+}
+
+async function contractBalance(account, contractId, config, json) {
+  if (!sdk.StrKey.isValidContract(contractId)) {
+    fail(`"${contractId}" is not a valid contract id (expected C...).`);
+  }
+
+  const server = new sdk.rpc.Server(config.rpcUrl, {
+    allowHttp: config.rpcUrl.startsWith("http://"),
+  });
+
+  const contract = new sdk.Contract(contractId);
+  const op = contract.call("balance", new sdk.Address(account).toScVal());
+
+  // Read-only: a throwaway source with sequence 0 is sufficient for simulation.
+  const source = new sdk.Account(sdk.Keypair.random().publicKey(), "0");
+  const tx = new sdk.TransactionBuilder(source, {
+    fee: sdk.BASE_FEE,
+    networkPassphrase: config.passphrase,
+  })
+    .addOperation(op)
+    .setTimeout(30)
+    .build();
+
+  let sim;
+  try {
+    sim = await server.simulateTransaction(tx);
+  } catch (err) {
+    fail(`Simulation request failed: ${err.message}`);
+  }
+
+  if (sdk.rpc.Api.isSimulationError(sim)) {
+    fail(`Contract balance query failed: ${sim.error}`);
+  }
+
+  const retval = sim.result && sim.result.retval;
+  const balance = retval ? sdk.scValToNative(retval) : null;
+
+  if (json) {
+    printJson({ account, contract: contractId, network: config.network, balance });
+    return;
+  }
+
+  console.log(`Account:  ${account}`);
+  console.log(`Contract: ${contractId} (${config.network})`);
+  console.log(`Balance:  ${balance === null ? "n/a" : balance.toString()}`);
+}
+
+module.exports = { run, HELP };

--- a/packages/core/bin/commands/codegen.js
+++ b/packages/core/bin/commands/codegen.js
@@ -1,0 +1,135 @@
+"use strict";
+
+// axionvera-cli codegen — generate a TypeScript contract client from a WASM spec.
+
+const path = require("path");
+const fs = require("fs");
+
+const PKG_ROOT = path.join(__dirname, "..", "..");
+
+const HELP = `
+axionvera-cli codegen — Soroban contract TypeScript code generator
+
+Usage:
+  axionvera-cli codegen <contract.wasm> [options]
+
+Options:
+  --out, -o <dir>     Output directory (default: current directory)
+  --name, -n <name>   Class name (default: derived from wasm filename)
+  --import <path>     Import path for @axionvera/core (default: "@axionvera/core")
+  --help, -h          Show this help message
+
+Example:
+  axionvera-cli codegen ./target/wasm32-unknown-unknown/release/my_token.wasm \\
+    --out ./src/contracts \\
+    --name TokenContract
+`;
+
+function run(argv) {
+  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) {
+    console.log(HELP);
+    return;
+  }
+
+  let wasmPath = null;
+  let outDir = process.cwd();
+  let className = null;
+  let coreImport = "@axionvera/core";
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--out" || arg === "-o") {
+      outDir = argv[++i];
+    } else if (arg === "--name" || arg === "-n") {
+      className = argv[++i];
+    } else if (arg === "--import") {
+      coreImport = argv[++i];
+    } else if (!arg.startsWith("-")) {
+      wasmPath = arg;
+    } else {
+      console.error(`Unknown option: ${arg}. Run with --help for usage.`);
+      process.exit(1);
+    }
+  }
+
+  if (!wasmPath) {
+    console.error("Error: <contract.wasm> path is required.");
+    console.log(HELP);
+    process.exit(1);
+  }
+
+  const resolvedWasm = path.resolve(process.cwd(), wasmPath);
+  if (!fs.existsSync(resolvedWasm)) {
+    console.error(`Error: WASM file not found: ${resolvedWasm}`);
+    process.exit(1);
+  }
+
+  if (!className) {
+    const base = path.basename(resolvedWasm, ".wasm");
+    className = base
+      .replace(/[-_](.)/g, (_, c) => c.toUpperCase())
+      .replace(/^(.)/, (_, c) => c.toUpperCase());
+    if (!className.toLowerCase().endsWith("contract")) {
+      className += "Contract";
+    }
+  }
+
+  let parseWasm, generateContractClass;
+  try {
+    ({ parseWasm, generateContractClass } = requireCodegen());
+  } catch (err) {
+    console.error(`Error loading codegen modules: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.log(`Parsing WASM spec from: ${resolvedWasm}`);
+
+  let spec;
+  try {
+    spec = parseWasm(resolvedWasm);
+  } catch (err) {
+    console.error(`Error parsing WASM: ${err.message}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `Found ${spec.functions.length} function(s), ` +
+      `${spec.structs.length} struct(s), ` +
+      `${spec.enums.length} enum(s).`
+  );
+
+  const source = generateContractClass(spec, className, coreImport);
+
+  const resolvedOut = path.resolve(process.cwd(), outDir);
+  fs.mkdirSync(resolvedOut, { recursive: true });
+
+  const outFile = path.join(resolvedOut, `${className}.ts`);
+  fs.writeFileSync(outFile, source, "utf8");
+
+  console.log(`Generated: ${outFile}`);
+}
+
+// Loads the codegen implementation from dist (production) or src (ts-node).
+function requireCodegen() {
+  const distParser = path.join(PKG_ROOT, "dist/codegen/wasmParser.js");
+  const distGenerator = path.join(PKG_ROOT, "dist/codegen/generator.js");
+  if (fs.existsSync(distParser) && fs.existsSync(distGenerator)) {
+    return {
+      parseWasm: require(distParser).parseWasm,
+      generateContractClass: require(distGenerator).generateContractClass,
+    };
+  }
+  const srcParser = path.join(PKG_ROOT, "src/codegen/wasmParser.ts");
+  if (fs.existsSync(srcParser)) {
+    try {
+      require("ts-node/register");
+    } catch (_) {}
+    return {
+      parseWasm: require(srcParser).parseWasm,
+      generateContractClass: require(path.join(PKG_ROOT, "src/codegen/generator.ts")).generateContractClass,
+    };
+  }
+  throw new Error("Could not locate codegen modules. Run `npm run build` in packages/core first.");
+}
+
+module.exports = { run, HELP };

--- a/packages/core/bin/commands/invoke.js
+++ b/packages/core/bin/commands/invoke.js
@@ -1,0 +1,200 @@
+"use strict";
+
+// axionvera-cli invoke — execute a contract method.
+//
+// With no --source the call is simulated read-only and the decoded return value
+// is printed. With --source <secret> the call is assembled, signed, submitted,
+// and polled to completion.
+
+const {
+  resolveNetwork,
+  parseArgs,
+  parseScVal,
+  printJson,
+  sdk,
+  fail,
+} = require("./shared");
+
+const HELP = `
+axionvera-cli invoke — execute a contract method
+
+Usage:
+  axionvera-cli invoke <contractId> <method> [--arg <value> ...] [options]
+
+Arguments:
+  <contractId>           Soroban contract id (C...)
+  <method>               Contract method name to call
+
+Options:
+  --arg <value>          A method argument. Repeatable; order is preserved.
+                         Use "type:value" to force a type, e.g.
+                         address:G..., i128:1000, symbol:transfer, bool:true.
+                         Without a prefix the type is inferred.
+  --source <secret>      Sign and submit with this secret key (S...). Omit for a
+                         read-only simulation.
+  --as <publicKey>       Source account to simulate as (read-only); defaults to a
+                         throwaway account when omitted.
+  --fee <stroops>        Base fee in stroops (default: 100)
+  --network, -n <name>   testnet | futurenet | mainnet (default: testnet)
+  --rpc <url>            Override the Soroban RPC URL
+  --yes, -y              Skip the mainnet write confirmation
+  --json                 Print result as JSON
+  --help, -h             Show this help message
+
+Examples:
+  # Read-only call
+  axionvera-cli invoke CBIE...TOKEN balance --arg address:GD5J...KUZ2V
+
+  # Signed write
+  axionvera-cli invoke CBIE...TOKEN transfer \\
+    --arg address:GFROM... --arg address:GTO... --arg i128:1000 \\
+    --source SB... --network testnet
+`;
+
+async function run(argv) {
+  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) {
+    console.log(HELP);
+    return;
+  }
+
+  const { flags, positionals } = parseArgs(argv, {
+    aliases: { "-n": "network", "-y": "yes" },
+    booleans: ["yes", "json"],
+    arrays: ["arg"],
+  });
+
+  const [contractId, method] = positionals;
+  if (!contractId) fail("A <contractId> is required.");
+  if (!sdk.StrKey.isValidContract(contractId)) {
+    fail(`"${contractId}" is not a valid contract id (expected C...).`);
+  }
+  if (!method) fail("A <method> name is required.");
+
+  const config = resolveNetwork(flags);
+  const server = new sdk.rpc.Server(config.rpcUrl, {
+    allowHttp: config.rpcUrl.startsWith("http://"),
+  });
+
+  let scArgs;
+  try {
+    scArgs = (flags.arg || []).map(parseScVal);
+  } catch (err) {
+    fail(`Could not parse arguments: ${err.message}`);
+  }
+
+  const contract = new sdk.Contract(contractId);
+  const op = contract.call(method, ...scArgs);
+
+  const writing = Boolean(flags.source);
+  let keypair = null;
+  let sourceAccount;
+
+  if (writing) {
+    try {
+      keypair = sdk.Keypair.fromSecret(flags.source);
+    } catch (_) {
+      fail("Invalid --source secret key (expected S...).");
+    }
+    sourceAccount = await loadAccount(server, keypair.publicKey(), config.network);
+  } else if (flags.as) {
+    if (!sdk.StrKey.isValidEd25519PublicKey(flags.as)) {
+      fail(`"${flags.as}" is not a valid account public key (expected G...).`);
+    }
+    sourceAccount = await loadAccount(server, flags.as, config.network);
+  } else {
+    sourceAccount = new sdk.Account(sdk.Keypair.random().publicKey(), "0");
+  }
+
+  const tx = new sdk.TransactionBuilder(sourceAccount, {
+    fee: flags.fee || sdk.BASE_FEE,
+    networkPassphrase: config.passphrase,
+  })
+    .addOperation(op)
+    .setTimeout(30)
+    .build();
+
+  let sim;
+  try {
+    sim = await server.simulateTransaction(tx);
+  } catch (err) {
+    fail(`Simulation request failed: ${err.message}`);
+  }
+  if (sdk.rpc.Api.isSimulationError(sim)) {
+    fail(`Simulation failed: ${sim.error}`);
+  }
+
+  const retval = sim.result && sim.result.retval;
+  const decoded = retval ? sdk.scValToNative(retval) : null;
+
+  if (!writing) {
+    if (flags.json) {
+      printJson({ contract: contractId, method, result: decoded, simulated: true });
+    } else {
+      console.log(`Simulated ${method} on ${contractId} (${config.network})`);
+      console.log(`Result: ${formatResult(decoded)}`);
+    }
+    return;
+  }
+
+  if (config.network === "mainnet" && !flags.yes) {
+    fail("Refusing to submit a mainnet transaction without --yes.");
+  }
+
+  const prepared = sdk.rpc.assembleTransaction(tx, sim).build();
+  prepared.sign(keypair);
+
+  let sent;
+  try {
+    sent = await server.sendTransaction(prepared);
+  } catch (err) {
+    fail(`Submission failed: ${err.message}`);
+  }
+  if (sent.status === "ERROR") {
+    fail(`Submission rejected: ${JSON.stringify(sent.errorResult || sent)}`);
+  }
+
+  const final = await poll(server, sent.hash);
+
+  if (flags.json) {
+    printJson({
+      contract: contractId,
+      method,
+      hash: sent.hash,
+      status: final.status,
+      result: final.returnValue ? sdk.scValToNative(final.returnValue) : decoded,
+    });
+    return;
+  }
+
+  console.log(`Submitted ${method} on ${contractId} (${config.network})`);
+  console.log(`Hash:   ${sent.hash}`);
+  console.log(`Status: ${final.status}`);
+  const resultValue = final.returnValue ? sdk.scValToNative(final.returnValue) : decoded;
+  console.log(`Result: ${formatResult(resultValue)}`);
+}
+
+async function loadAccount(server, publicKey, network) {
+  try {
+    return await server.getAccount(publicKey);
+  } catch (err) {
+    fail(`Could not load account ${publicKey} on ${network}: ${err.message}`);
+  }
+}
+
+async function poll(server, hash, attempts = 30, intervalMs = 1000) {
+  for (let i = 0; i < attempts; i++) {
+    const res = await server.getTransaction(hash);
+    if (res.status !== "NOT_FOUND") return res;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  fail(`Timed out waiting for transaction ${hash}.`);
+}
+
+function formatResult(value) {
+  if (value === null || value === undefined) return "(void)";
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "object") return JSON.stringify(value, (_k, v) => (typeof v === "bigint" ? v.toString() : v));
+  return String(value);
+}
+
+module.exports = { run, HELP };

--- a/packages/core/bin/commands/network.js
+++ b/packages/core/bin/commands/network.js
@@ -1,0 +1,73 @@
+"use strict";
+
+// axionvera-cli network — show the resolved network configuration and, unless
+// --no-ping is given, check RPC reachability.
+
+const { resolveNetwork, parseArgs, printJson, sdk, fail } = require("./shared");
+
+const HELP = `
+axionvera-cli network — show the resolved network configuration
+
+Usage:
+  axionvera-cli network [options]
+
+Options:
+  --network, -n <name>   testnet | futurenet | mainnet (default: testnet)
+  --rpc <url>            Override the Soroban RPC URL
+  --horizon <url>        Override the Horizon URL
+  --json                 Print configuration as JSON
+  --no-ping              Skip the RPC health/ledger check
+  --help, -h             Show this help message
+
+Examples:
+  axionvera-cli network
+  axionvera-cli network --network mainnet --no-ping
+`;
+
+async function run(argv) {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(HELP);
+    return;
+  }
+
+  const { flags } = parseArgs(argv, {
+    aliases: { "-n": "network" },
+    booleans: ["json", "no-ping", "ping"],
+  });
+
+  const config = resolveNetwork(flags);
+  const ping = flags["no-ping"] ? false : true;
+
+  let health = null;
+  let latestLedger = null;
+  if (ping) {
+    try {
+      const server = new sdk.rpc.Server(config.rpcUrl, {
+        allowHttp: config.rpcUrl.startsWith("http://"),
+      });
+      const healthRes = await server.getHealth();
+      health = healthRes.status || "unknown";
+      const ledger = await server.getLatestLedger();
+      latestLedger = ledger.sequence;
+    } catch (err) {
+      health = `unreachable (${err.message})`;
+    }
+  }
+
+  if (flags.json) {
+    printJson({ ...config, rpcHealth: health, latestLedger });
+    return;
+  }
+
+  console.log(`Network:           ${config.network}`);
+  console.log(`Passphrase:        ${config.passphrase}`);
+  console.log(`Soroban RPC URL:   ${config.rpcUrl}`);
+  console.log(`Horizon URL:       ${config.horizonUrl}`);
+  console.log(`Friendbot URL:     ${config.friendbotUrl || "(none — funded accounts only)"}`);
+  if (ping) {
+    console.log(`RPC health:        ${health}`);
+    console.log(`Latest ledger:     ${latestLedger ?? "n/a"}`);
+  }
+}
+
+module.exports = { run, HELP };

--- a/packages/core/bin/commands/shared.js
+++ b/packages/core/bin/commands/shared.js
@@ -1,0 +1,184 @@
+"use strict";
+
+// Shared helpers for the axionvera-cli subcommands: argument parsing, network
+// resolution, ScVal coercion, and output formatting. Kept dependency-free apart
+// from @stellar/stellar-sdk so the CLI runs without building the SDK source.
+
+const sdk = require("@stellar/stellar-sdk");
+const { Networks, StrKey, Address, nativeToScVal } = sdk;
+
+// ─── Network configuration ──────────────────────────────────────────────────
+
+const NETWORKS = {
+  testnet: {
+    passphrase: Networks.TESTNET,
+    rpcUrl: "https://soroban-testnet.stellar.org",
+    horizonUrl: "https://horizon-testnet.stellar.org",
+    friendbotUrl: "https://friendbot.stellar.org",
+  },
+  futurenet: {
+    passphrase: Networks.FUTURENET,
+    rpcUrl: "https://rpc-futurenet.stellar.org",
+    horizonUrl: "https://horizon-futurenet.stellar.org",
+    friendbotUrl: "https://friendbot-futurenet.stellar.org",
+  },
+  mainnet: {
+    passphrase: Networks.PUBLIC,
+    rpcUrl: "https://mainnet.sorobanrpc.com",
+    horizonUrl: "https://horizon.stellar.org",
+    friendbotUrl: null,
+  },
+};
+
+/**
+ * Resolves the effective network configuration from flags and environment.
+ * Precedence: explicit flag > environment variable > network default.
+ * Recognised env vars: AXIONVERA_NETWORK, AXIONVERA_RPC_URL,
+ * AXIONVERA_HORIZON_URL, AXIONVERA_NETWORK_PASSPHRASE.
+ */
+function resolveNetwork(opts = {}) {
+  const name = (opts.network || process.env.AXIONVERA_NETWORK || "testnet").toLowerCase();
+  const base = NETWORKS[name];
+  if (!base) {
+    fail(`Unknown network "${name}". Supported: ${Object.keys(NETWORKS).join(", ")}.`);
+  }
+  return {
+    network: name,
+    passphrase: opts.passphrase || process.env.AXIONVERA_NETWORK_PASSPHRASE || base.passphrase,
+    rpcUrl: opts.rpc || process.env.AXIONVERA_RPC_URL || base.rpcUrl,
+    horizonUrl: opts.horizon || process.env.AXIONVERA_HORIZON_URL || base.horizonUrl,
+    friendbotUrl: base.friendbotUrl,
+  };
+}
+
+// ─── Argument parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Minimal flag parser. Supports "--flag value", "--flag=value", boolean flags,
+ * short aliases (mapped by the caller), and repeated flags collected into arrays.
+ * Anything not starting with "-" is collected as a positional.
+ *
+ * @param {string[]} argv     - Arguments after the subcommand name.
+ * @param {object}   spec     - { aliases: {"-o":"out"}, booleans: ["yes"], arrays: ["arg"] }
+ */
+function parseArgs(argv, spec = {}) {
+  const aliases = spec.aliases || {};
+  const booleans = new Set(spec.booleans || []);
+  const arrays = new Set(spec.arrays || []);
+  const flags = {};
+  const positionals = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    let token = argv[i];
+    if (token.startsWith("-")) {
+      let value;
+      const eq = token.indexOf("=");
+      if (eq !== -1) {
+        value = token.slice(eq + 1);
+        token = token.slice(0, eq);
+      }
+      let key = aliases[token] || token.replace(/^--?/, "");
+      if (booleans.has(key)) {
+        flags[key] = true;
+        continue;
+      }
+      if (value === undefined) {
+        value = argv[++i];
+        if (value === undefined) fail(`Missing value for option "${token}".`);
+      }
+      if (arrays.has(key)) {
+        (flags[key] = flags[key] || []).push(value);
+      } else {
+        flags[key] = value;
+      }
+    } else {
+      positionals.push(token);
+    }
+  }
+  return { flags, positionals };
+}
+
+// ─── ScVal coercion ────────────────────────────────────────────────────────────
+
+const TYPE_PREFIX = /^(address|account|contract|bool|u32|i32|u64|i64|u128|i128|u256|i256|symbol|string|bytes):([\s\S]*)$/;
+
+/**
+ * Converts a CLI argument string into an ScVal for a contract call.
+ *
+ * Accepts an explicit "type:value" prefix (e.g. "i128:1000", "address:G...",
+ * "symbol:transfer", "bool:true"). Without a prefix the type is inferred:
+ * Stellar addresses become Address values, plain integers become i128, "true"/
+ * "false" become bool, and everything else becomes a string.
+ */
+function parseScVal(raw) {
+  const match = TYPE_PREFIX.exec(raw);
+  if (match) {
+    return coerce(match[1], match[2]);
+  }
+  // Inference
+  if (isStellarAddress(raw)) return new Address(raw).toScVal();
+  if (/^-?\d+$/.test(raw)) return nativeToScVal(BigInt(raw), { type: "i128" });
+  if (raw === "true" || raw === "false") return nativeToScVal(raw === "true");
+  return nativeToScVal(raw, { type: "string" });
+}
+
+function coerce(type, value) {
+  switch (type) {
+    case "address":
+    case "account":
+    case "contract":
+      return new Address(value).toScVal();
+    case "bool":
+      return nativeToScVal(value === "true");
+    case "u32":
+    case "i32":
+      return nativeToScVal(Number(value), { type });
+    case "u64":
+    case "i64":
+    case "u128":
+    case "i128":
+    case "u256":
+    case "i256":
+      return nativeToScVal(BigInt(value), { type });
+    case "symbol":
+      return nativeToScVal(value, { type: "symbol" });
+    case "string":
+      return nativeToScVal(value, { type: "string" });
+    case "bytes":
+      return nativeToScVal(Buffer.from(value, "hex"));
+    default:
+      fail(`Unsupported argument type "${type}".`);
+  }
+}
+
+function isStellarAddress(value) {
+  return StrKey.isValidEd25519PublicKey(value) || StrKey.isValidContract(value);
+}
+
+// ─── Output helpers ──────────────────────────────────────────────────────────
+
+/** JSON.stringify replacer that renders BigInt as a string. */
+function bigintReplacer(_key, value) {
+  return typeof value === "bigint" ? value.toString() : value;
+}
+
+function printJson(value) {
+  console.log(JSON.stringify(value, bigintReplacer, 2));
+}
+
+function fail(message) {
+  console.error(`Error: ${message}`);
+  process.exit(1);
+}
+
+module.exports = {
+  NETWORKS,
+  resolveNetwork,
+  parseArgs,
+  parseScVal,
+  isStellarAddress,
+  printJson,
+  bigintReplacer,
+  fail,
+  sdk,
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,6 +8,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
+    "bin",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
Closes #215 

Expands `axionvera-cli` from a codegen-only tool into a multi-command CLI for interacting with Axionvera contracts and Stellar/Soroban networks. Commands talk to the network directly through @stellar/stellar-sdk, so the CLI runs standalone without building the SDK source.

## Commands
- `network` — show the resolved network configuration (passphrase, Soroban RPC, Horizon, friendbot) and check RPC health/latest ledger. Resolution precedence is flag > environment variable > default.
- `balance <account>` — query classic balances (XLM + trustlines) from Horizon, or a Soroban token contract balance via read-only simulation with `--contract <id>`.
- `invoke <contractId> <method>` — execute a contract method. Read-only simulation by default; with `--source <secret>` the transaction is assembled, signed, submitted, and polled. Mainnet writes require `--yes`.
- `codegen` — unchanged WASM-to-TypeScript generation, preserved behind the new dispatcher.

## Configuration
Network is selected via `--network` (testnet/futurenet/mainnet), `--rpc`, `--horizon`, `--passphrase`, or the matching `AXIONVERA_*` environment variables.

## Argument typing
`invoke --arg` accepts explicit `type:value` prefixes (address, bool, u32/i32, u64/i64/u128/i128/u256/i256, symbol, string, bytes) and falls back to inference (addresses, integers as i128, booleans, otherwise string).

## Packaging
Added `bin` to the `files` array in `packages/core/package.json` so the command modules are published alongside the binary entry point.

## Documentation
Added `docs/CLI.md` covering installation, network configuration, every command and option, argument types, read-vs-write behavior, and a secret-key security note.

## Acceptance criteria
- CLI is documented — `docs/CLI.md` plus per-command `--help`.
- Commands execute successfully — verified help/version output, input validation, ScVal coercion and transaction building across argument types, graceful network-failure handling, and a live `balance` query against Horizon.

## Files
- packages/core/bin/axionvera-cli.js — multi-command dispatcher
- packages/core/bin/commands/{shared,network,balance,invoke,codegen}.js
- packages/core/package.json — include `bin` in published files
- docs/CLI.md — CLI documentation

Note: the existing typecheck/test CI jobs are currently red on `main` due to a pre-existing broken merge unrelated to this change. The CLI is plain JavaScript under `bin/` and is not part of the TypeScript build/lint/test, so it introduces no new failures.
