### PR TITLE
feat: add contract interaction replay framework

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,3 +81,16 @@ export { isValidXDR, assertValidXDR, MAX_XDR_STRING_LENGTH } from './utils/xdrVa
 export * from './test/msw/setup';
 export * from './test/msw/handlers';
 export { server } from './test/msw/server';
+
+// Replay Framework
+export { InteractionRecorder, ReplayEngine, ReplayValidator } from './replay';
+export type {
+  ContractHandlers,
+  RecordedInteraction,
+  RecordingMetadata,
+  ReplaySession,
+  ReplayResult,
+  ValidationResult,
+  ReplayValidationReport,
+  ReplayOptions,
+} from './replay';

--- a/src/replay/engine.ts
+++ b/src/replay/engine.ts
@@ -1,0 +1,84 @@
+import { RecordedInteraction, ReplayOptions, ReplayResult, ReplaySession } from './types';
+
+/**
+ * A contract handler that the ReplayEngine dispatches interactions to.
+ * Keyed by contractId → method → async function that accepts the recorded args.
+ */
+export type ContractHandlers = Record<
+  string,
+  Record<string, (...args: unknown[]) => Promise<unknown>>
+>;
+
+/**
+ * Replays a {@link ReplaySession} against a set of contract handler functions.
+ *
+ * @example
+ * ```typescript
+ * const engine = new ReplayEngine({
+ *   'CONTRACT_ID': { deposit: (amount) => vault.deposit({ amount: amount as bigint }) }
+ * });
+ * const results = await engine.replay(session);
+ * ```
+ */
+export class ReplayEngine {
+  constructor(private readonly handlers: ContractHandlers) {}
+
+  /**
+   * Replays all interactions in the session and returns per-interaction results.
+   */
+  async replay(session: ReplaySession, options: ReplayOptions = {}): Promise<ReplayResult[]> {
+    const results: ReplayResult[] = [];
+
+    for (const interaction of session.interactions) {
+      const result = await this.replayOne(interaction);
+      results.push(result);
+
+      if (options.stopOnFailure && !result.success) {
+        break;
+      }
+    }
+
+    return results;
+  }
+
+  private async replayOne(interaction: RecordedInteraction): Promise<ReplayResult> {
+    const { id, contractId, method, args } = interaction;
+    const handler = this.handlers[contractId]?.[method];
+    const start = Date.now();
+
+    if (!handler) {
+      return {
+        interactionId: id,
+        contractId,
+        method,
+        success: false,
+        error: { name: 'Error', message: `No handler registered for ${contractId}.${method}` },
+        durationMs: 0,
+      };
+    }
+
+    try {
+      const result = await handler(...args);
+      return {
+        interactionId: id,
+        contractId,
+        method,
+        success: true,
+        result,
+        durationMs: Date.now() - start,
+      };
+    } catch (err) {
+      return {
+        interactionId: id,
+        contractId,
+        method,
+        success: false,
+        error: {
+          name: err instanceof Error ? err.name : 'Error',
+          message: err instanceof Error ? err.message : String(err),
+        },
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+}

--- a/src/replay/index.ts
+++ b/src/replay/index.ts
@@ -1,0 +1,13 @@
+export { InteractionRecorder } from './recorder';
+export { ReplayEngine } from './engine';
+export { ReplayValidator } from './validator';
+export type { ContractHandlers } from './engine';
+export type {
+  RecordedInteraction,
+  RecordingMetadata,
+  ReplaySession,
+  ReplayResult,
+  ValidationResult,
+  ReplayValidationReport,
+  ReplayOptions,
+} from './types';

--- a/src/replay/recorder.ts
+++ b/src/replay/recorder.ts
@@ -1,0 +1,84 @@
+import { RecordedInteraction, RecordingMetadata, ReplaySession } from './types';
+
+/** Generates a simple unique ID without external dependencies. */
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+/**
+ * Records contract interactions (calls + results) for later replay.
+ *
+ * @example
+ * ```typescript
+ * const recorder = new InteractionRecorder();
+ * const result = await recorder.record('CONTRACT_ID', 'deposit', [1000n], () => vault.deposit({ amount: 1000n }));
+ * const session = recorder.exportSession();
+ * ```
+ */
+export class InteractionRecorder {
+  private interactions: RecordedInteraction[] = [];
+
+  /**
+   * Wraps a contract call and records the interaction (args + result/error).
+   *
+   * @param contractId - The contract being called
+   * @param method - The method name
+   * @param args - Arguments passed to the method
+   * @param fn - The async function that performs the contract call
+   * @param metadata - Optional metadata to attach
+   */
+  async record<T>(
+    contractId: string,
+    method: string,
+    args: unknown[],
+    fn: () => Promise<T>,
+    metadata?: RecordingMetadata
+  ): Promise<T> {
+    const interaction: RecordedInteraction = {
+      id: uid(),
+      timestamp: new Date().toISOString(),
+      contractId,
+      method,
+      args,
+      metadata,
+    };
+
+    try {
+      const result = await fn();
+      interaction.result = result;
+      this.interactions.push(interaction);
+      return result;
+    } catch (err) {
+      interaction.error = {
+        name: err instanceof Error ? err.name : 'Error',
+        message: err instanceof Error ? err.message : String(err),
+      };
+      this.interactions.push(interaction);
+      throw err;
+    }
+  }
+
+  /** Returns a copy of all recorded interactions. */
+  getInteractions(): RecordedInteraction[] {
+    return [...this.interactions];
+  }
+
+  /** Clears all recorded interactions. */
+  clear(): void {
+    this.interactions = [];
+  }
+
+  /** Exports all recorded interactions as a serialisable ReplaySession. */
+  exportSession(): ReplaySession {
+    return {
+      id: uid(),
+      createdAt: new Date().toISOString(),
+      interactions: this.getInteractions(),
+    };
+  }
+
+  /** Restores a previously exported session (appends to current interactions). */
+  importSession(session: ReplaySession): void {
+    this.interactions.push(...session.interactions);
+  }
+}

--- a/src/replay/types.ts
+++ b/src/replay/types.ts
@@ -1,0 +1,78 @@
+/**
+ * Represents a single recorded contract interaction.
+ */
+export type RecordedInteraction = {
+  /** Unique identifier for this interaction */
+  id: string;
+  /** ISO timestamp when the interaction was recorded */
+  timestamp: string;
+  /** The contract ID that was called */
+  contractId: string;
+  /** The method name that was invoked */
+  method: string;
+  /** Serialized arguments passed to the method */
+  args: unknown[];
+  /** The result returned by the call (undefined if it errored) */
+  result?: unknown;
+  /** The error thrown (undefined if successful) */
+  error?: { message: string; name: string };
+  /** Optional transaction metadata */
+  metadata?: RecordingMetadata;
+};
+
+export type RecordingMetadata = {
+  network?: string;
+  sourceAccount?: string;
+  txHash?: string;
+  ledger?: number;
+  /** Arbitrary extra context */
+  [key: string]: unknown;
+};
+
+/**
+ * A collection of recorded interactions (a replay session).
+ */
+export type ReplaySession = {
+  id: string;
+  createdAt: string;
+  interactions: RecordedInteraction[];
+};
+
+/**
+ * The outcome of replaying a single interaction.
+ */
+export type ReplayResult = {
+  interactionId: string;
+  contractId: string;
+  method: string;
+  success: boolean;
+  result?: unknown;
+  error?: { message: string; name: string };
+  durationMs: number;
+};
+
+/**
+ * The outcome of validating a replay against its recording.
+ */
+export type ValidationResult = {
+  interactionId: string;
+  passed: boolean;
+  /** Human-readable description of what differed, if anything */
+  diff?: string;
+};
+
+export type ReplayValidationReport = {
+  sessionId: string;
+  total: number;
+  passed: number;
+  failed: number;
+  results: ValidationResult[];
+};
+
+/**
+ * Options for the ReplayEngine.
+ */
+export type ReplayOptions = {
+  /** Stop replaying after the first failure (default: false) */
+  stopOnFailure?: boolean;
+};

--- a/src/replay/validator.ts
+++ b/src/replay/validator.ts
@@ -1,0 +1,89 @@
+import { RecordedInteraction, ReplayResult, ReplaySession, ReplayValidationReport, ValidationResult } from './types';
+
+/**
+ * Compares replay results against the original recorded interactions.
+ *
+ * @example
+ * ```typescript
+ * const validator = new ReplayValidator();
+ * const report = validator.validate(session, replayResults);
+ * console.log(`${report.passed}/${report.total} passed`);
+ * ```
+ */
+export class ReplayValidator {
+  /**
+   * Validates a set of replay results against their original recordings.
+   *
+   * @param session - The original recorded session
+   * @param replayResults - Results produced by {@link ReplayEngine.replay}
+   */
+  validate(session: ReplaySession, replayResults: ReplayResult[]): ReplayValidationReport {
+    const resultMap = new Map(replayResults.map((r) => [r.interactionId, r]));
+
+    const results: ValidationResult[] = session.interactions.map((interaction) => {
+      const replayResult = resultMap.get(interaction.id);
+
+      if (!replayResult) {
+        return {
+          interactionId: interaction.id,
+          passed: false,
+          diff: 'Interaction was not replayed',
+        };
+      }
+
+      return this.compareOne(interaction, replayResult);
+    });
+
+    const passed = results.filter((r) => r.passed).length;
+
+    return {
+      sessionId: session.id,
+      total: results.length,
+      passed,
+      failed: results.length - passed,
+      results,
+    };
+  }
+
+  private compareOne(
+    recorded: RecordedInteraction,
+    replayed: ReplayResult
+  ): ValidationResult {
+    // Both errored — compare error messages
+    if (recorded.error && !replayed.success) {
+      const match = recorded.error.message === replayed.error?.message;
+      return {
+        interactionId: recorded.id,
+        passed: match,
+        diff: match ? undefined : `Error mismatch: recorded "${recorded.error.message}" vs replayed "${replayed.error?.message}"`,
+      };
+    }
+
+    // Originally errored but replay succeeded (or vice versa)
+    if (!!recorded.error !== !replayed.success) {
+      return {
+        interactionId: recorded.id,
+        passed: false,
+        diff: recorded.error
+          ? `Expected an error ("${recorded.error.message}") but replay succeeded`
+          : `Expected success but replay errored: "${replayed.error?.message}"`,
+      };
+    }
+
+    // Both succeeded — deep compare results
+    const recordedJson = JSON.stringify(recorded.result, replacer);
+    const replayedJson = JSON.stringify(replayed.result, replacer);
+    const match = recordedJson === replayedJson;
+
+    return {
+      interactionId: recorded.id,
+      passed: match,
+      diff: match ? undefined : `Result mismatch:\n  recorded: ${recordedJson}\n  replayed: ${replayedJson}`,
+    };
+  }
+}
+
+/** JSON replacer that serialises BigInt values so they survive stringify. */
+function replacer(_key: string, value: unknown): unknown {
+  return typeof value === 'bigint' ? `__bigint__${value.toString()}` : value;
+}

--- a/tests/replay/replay.test.ts
+++ b/tests/replay/replay.test.ts
@@ -1,0 +1,277 @@
+import { InteractionRecorder } from '../../src/replay/recorder';
+import { ReplayEngine, ContractHandlers } from '../../src/replay/engine';
+import { ReplayValidator } from '../../src/replay/validator';
+import { ReplaySession } from '../../src/replay/types';
+
+// ---------------------------------------------------------------------------
+// InteractionRecorder
+// ---------------------------------------------------------------------------
+describe('InteractionRecorder', () => {
+  let recorder: InteractionRecorder;
+
+  beforeEach(() => {
+    recorder = new InteractionRecorder();
+  });
+
+  it('records a successful interaction', async () => {
+    await recorder.record('C1', 'deposit', [1000n], async () => ({ txHash: 'abc' }));
+    const [interaction] = recorder.getInteractions();
+    expect(interaction.contractId).toBe('C1');
+    expect(interaction.method).toBe('deposit');
+    expect(interaction.args).toEqual([1000n]);
+    expect(interaction.result).toEqual({ txHash: 'abc' });
+    expect(interaction.error).toBeUndefined();
+  });
+
+  it('records a failed interaction and re-throws', async () => {
+    await expect(
+      recorder.record('C1', 'withdraw', [500n], async () => {
+        throw new Error('insufficient funds');
+      })
+    ).rejects.toThrow('insufficient funds');
+
+    const [interaction] = recorder.getInteractions();
+    expect(interaction.error).toEqual({ name: 'Error', message: 'insufficient funds' });
+    expect(interaction.result).toBeUndefined();
+  });
+
+  it('attaches optional metadata', async () => {
+    await recorder.record('C1', 'balance', [], async () => 100n, { network: 'testnet' });
+    const [interaction] = recorder.getInteractions();
+    expect(interaction.metadata?.network).toBe('testnet');
+  });
+
+  it('getInteractions returns a copy', () => {
+    const interactions = recorder.getInteractions();
+    interactions.push({} as any);
+    expect(recorder.getInteractions()).toHaveLength(0);
+  });
+
+  it('clear removes all interactions', async () => {
+    await recorder.record('C1', 'deposit', [], async () => 1);
+    recorder.clear();
+    expect(recorder.getInteractions()).toHaveLength(0);
+  });
+
+  it('exportSession returns a valid ReplaySession', async () => {
+    await recorder.record('C1', 'balance', [], async () => 50n);
+    const session = recorder.exportSession();
+    expect(session.id).toBeDefined();
+    expect(session.createdAt).toBeDefined();
+    expect(session.interactions).toHaveLength(1);
+  });
+
+  it('importSession appends interactions', async () => {
+    const external: ReplaySession = {
+      id: 'sess-1',
+      createdAt: new Date().toISOString(),
+      interactions: [
+        {
+          id: 'i1',
+          timestamp: new Date().toISOString(),
+          contractId: 'C2',
+          method: 'balance',
+          args: [],
+          result: 42n,
+        },
+      ],
+    };
+    recorder.importSession(external);
+    expect(recorder.getInteractions()).toHaveLength(1);
+    expect(recorder.getInteractions()[0].contractId).toBe('C2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ReplayEngine
+// ---------------------------------------------------------------------------
+describe('ReplayEngine', () => {
+  const makeSession = (overrides: Partial<ReplaySession['interactions'][number]> = {}): ReplaySession => ({
+    id: 'session-1',
+    createdAt: new Date().toISOString(),
+    interactions: [
+      {
+        id: 'i1',
+        timestamp: new Date().toISOString(),
+        contractId: 'CONTRACT',
+        method: 'deposit',
+        args: [1000n],
+        result: { txHash: 'abc' },
+        ...overrides,
+      },
+    ],
+  });
+
+  it('replays a successful interaction', async () => {
+    const handlers: ContractHandlers = {
+      CONTRACT: { deposit: async (amount) => ({ txHash: 'abc', amount }) },
+    };
+    const engine = new ReplayEngine(handlers);
+    const [result] = await engine.replay(makeSession());
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ txHash: 'abc', amount: 1000n });
+  });
+
+  it('returns failure when handler throws', async () => {
+    const handlers: ContractHandlers = {
+      CONTRACT: {
+        deposit: async () => { throw new Error('network error'); },
+      },
+    };
+    const engine = new ReplayEngine(handlers);
+    const [result] = await engine.replay(makeSession());
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toBe('network error');
+  });
+
+  it('returns failure when no handler is registered', async () => {
+    const engine = new ReplayEngine({});
+    const [result] = await engine.replay(makeSession());
+    expect(result.success).toBe(false);
+    expect(result.error?.message).toMatch(/No handler registered/);
+  });
+
+  it('stopOnFailure halts replay after first failure', async () => {
+    const session: ReplaySession = {
+      id: 's1',
+      createdAt: new Date().toISOString(),
+      interactions: [
+        { id: 'i1', timestamp: '', contractId: 'C', method: 'fail', args: [], result: undefined },
+        { id: 'i2', timestamp: '', contractId: 'C', method: 'ok', args: [], result: 1 },
+      ],
+    };
+    const handlers: ContractHandlers = {
+      C: {
+        fail: async () => { throw new Error('boom'); },
+        ok: jest.fn(async () => 1),
+      },
+    };
+    const engine = new ReplayEngine(handlers);
+    const results = await engine.replay(session, { stopOnFailure: true });
+    expect(results).toHaveLength(1);
+    expect(handlers['C']['ok']).not.toHaveBeenCalled();
+  });
+
+  it('records durationMs', async () => {
+    const handlers: ContractHandlers = { CONTRACT: { deposit: async () => 1 } };
+    const engine = new ReplayEngine(handlers);
+    const [result] = await engine.replay(makeSession());
+    expect(typeof result.durationMs).toBe('number');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ReplayValidator
+// ---------------------------------------------------------------------------
+describe('ReplayValidator', () => {
+  const validator = new ReplayValidator();
+
+  const makeSession = (...interactions: Partial<ReplaySession['interactions'][number]>[]): ReplaySession => ({
+    id: 'session-v',
+    createdAt: new Date().toISOString(),
+    interactions: interactions.map((i, idx) => ({
+      id: `i${idx}`,
+      timestamp: '',
+      contractId: 'C',
+      method: 'm',
+      args: [],
+      ...i,
+    })),
+  });
+
+  it('passes when results match', () => {
+    const session = makeSession({ result: { x: 1 } });
+    const results = [{ interactionId: 'i0', contractId: 'C', method: 'm', success: true, result: { x: 1 }, durationMs: 0 }];
+    const report = validator.validate(session, results);
+    expect(report.passed).toBe(1);
+    expect(report.failed).toBe(0);
+  });
+
+  it('fails when results differ', () => {
+    const session = makeSession({ result: { x: 1 } });
+    const results = [{ interactionId: 'i0', contractId: 'C', method: 'm', success: true, result: { x: 2 }, durationMs: 0 }];
+    const report = validator.validate(session, results);
+    expect(report.failed).toBe(1);
+    expect(report.results[0].diff).toMatch(/mismatch/);
+  });
+
+  it('passes when both errored with same message', () => {
+    const session = makeSession({ error: { name: 'Error', message: 'boom' } });
+    const results = [{ interactionId: 'i0', contractId: 'C', method: 'm', success: false, error: { name: 'Error', message: 'boom' }, durationMs: 0 }];
+    const report = validator.validate(session, results);
+    expect(report.passed).toBe(1);
+  });
+
+  it('fails when recorded error message differs', () => {
+    const session = makeSession({ error: { name: 'Error', message: 'boom' } });
+    const results = [{ interactionId: 'i0', contractId: 'C', method: 'm', success: false, error: { name: 'Error', message: 'other' }, durationMs: 0 }];
+    const report = validator.validate(session, results);
+    expect(report.failed).toBe(1);
+  });
+
+  it('fails when recorded success but replay errored', () => {
+    const session = makeSession({ result: 1 });
+    const results = [{ interactionId: 'i0', contractId: 'C', method: 'm', success: false, error: { name: 'Error', message: 'oops' }, durationMs: 0 }];
+    const report = validator.validate(session, results);
+    expect(report.failed).toBe(1);
+    expect(report.results[0].diff).toMatch(/Expected success/);
+  });
+
+  it('fails when interaction was not replayed', () => {
+    const session = makeSession({ result: 1 });
+    const report = validator.validate(session, []);
+    expect(report.failed).toBe(1);
+    expect(report.results[0].diff).toBe('Interaction was not replayed');
+  });
+
+  it('handles BigInt in results correctly', () => {
+    const session = makeSession({ result: 1000n });
+    const results = [{ interactionId: 'i0', contractId: 'C', method: 'm', success: true, result: 1000n, durationMs: 0 }];
+    const report = validator.validate(session, results);
+    expect(report.passed).toBe(1);
+  });
+
+  it('reports correct totals', () => {
+    const session = makeSession({ result: 1 }, { result: 2 });
+    const results = [
+      { interactionId: 'i0', contractId: 'C', method: 'm', success: true, result: 1, durationMs: 0 },
+      { interactionId: 'i1', contractId: 'C', method: 'm', success: true, result: 99, durationMs: 0 },
+    ];
+    const report = validator.validate(session, results);
+    expect(report.total).toBe(2);
+    expect(report.passed).toBe(1);
+    expect(report.failed).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: record → replay → validate
+// ---------------------------------------------------------------------------
+describe('Replay framework end-to-end', () => {
+  it('full record → replay → validate flow', async () => {
+    // 1. Record
+    const recorder = new InteractionRecorder();
+    await recorder.record('VAULT', 'deposit', [500n], async () => ({ txHash: 'hash-1' }));
+    await recorder.record('VAULT', 'balance', ['GABC'], async () => 500n);
+    const session = recorder.exportSession();
+
+    // 2. Replay
+    const handlers: ContractHandlers = {
+      VAULT: {
+        deposit: async () => ({ txHash: 'hash-1' }),
+        balance: async () => 500n,
+      },
+    };
+    const engine = new ReplayEngine(handlers);
+    const replayResults = await engine.replay(session);
+
+    // 3. Validate
+    const validator = new ReplayValidator();
+    const report = validator.validate(session, replayResults);
+
+    expect(report.total).toBe(2);
+    expect(report.passed).toBe(2);
+    expect(report.failed).toBe(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",


### PR DESCRIPTION
closes #232 

- Add InteractionRecorder to capture contract calls (args, result/error, metadata) and export/import sessions as plain JSON
- Add ReplayEngine to replay recorded sessions against handler functions with per-interaction results and stopOnFailure support
- Add ReplayValidator to deep-compare replay results against recordings, producing diffs and pass/fail totals (BigInt-safe)
- Export all replay classes and types from src/index.ts
- Fix tsconfig.json: ignoreDeprecations '6.0' → '5.0' (invalid in TS 5.9)
- Add 21 tests covering recorder, engine, validator, and e2e flow

Closes: Contract Interaction Replay Framework feature request