### PR TITLE
feat: add observability and diagnostics layer

### DIFF
--- a/src/diagnostics/diagnosticsManager.ts
+++ b/src/diagnostics/diagnosticsManager.ts
@@ -1,0 +1,95 @@
+﻿import { DiagnosticEvent, DiagnosticsReport } from '../observability/types';
+
+export class DiagnosticsManager {
+  private events: DiagnosticEvent[] = [];
+  private maxEvents: number;
+  private enabled: boolean;
+  private listeners: Set<(event: DiagnosticEvent) => void> = new Set();
+  private eventCounter = 0;
+
+  constructor(enabled = false, maxEvents = 500) {
+    this.enabled = enabled;
+    this.maxEvents = maxEvents;
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  record(type: string, data: Record<string, any> = {}): void {
+    if (!this.enabled) return;
+
+    this.eventCounter++;
+    const event: DiagnosticEvent = {
+      id: diag__,
+      type,
+      timestamp: Date.now(),
+      data,
+    };
+
+    this.events.push(event);
+
+    if (this.events.length > this.maxEvents) {
+      this.events.shift();
+    }
+
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch {}
+    }
+  }
+
+  onDiagnosticEvent(callback: (event: DiagnosticEvent) => void): () => void {
+    this.listeners.add(callback);
+    return () => this.listeners.delete(callback);
+  }
+
+  getEvents(filter?: { type?: string; since?: number }): DiagnosticEvent[] {
+    let filtered = [...this.events];
+
+    if (filter?.type) {
+      filtered = filtered.filter((e) => e.type === filter.type);
+    }
+    if (filter?.since) {
+      filtered = filtered.filter((e) => e.timestamp >= filter.since);
+    }
+
+    return filtered;
+  }
+
+  generateReport(): DiagnosticsReport {
+    const byType: Record<string, number> = {};
+    let errors = 0;
+    let warnings = 0;
+
+    for (const event of this.events) {
+      byType[event.type] = (byType[event.type] ?? 0) + 1;
+      if (event.type.startsWith('error')) errors++;
+      if (event.type.startsWith('warn')) warnings++;
+    }
+
+    return {
+      timestamp: Date.now(),
+      events: this.events,
+      summary: {
+        totalEvents: this.events.length,
+        byType,
+        errors,
+        warnings,
+      },
+    };
+  }
+
+  clear(): void {
+    this.events = [];
+  }
+
+  getEventCount(): number {
+    return this.events.length;
+  }
+}

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -1,0 +1,1 @@
+﻿export * from './diagnosticsManager';

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,0 +1,3 @@
+﻿export * from './types';
+export * from './tracer';
+export * from './observabilityService';

--- a/src/observability/observabilityService.ts
+++ b/src/observability/observabilityService.ts
@@ -1,7 +1,7 @@
-﻿import { Logger, LogLevel, CustomLogger } from '../utils/logger';
+import { Logger, CustomLogger } from '../utils/logger';
 import { Tracer } from './tracer';
 import { DiagnosticsManager } from '../diagnostics/diagnosticsManager';
-import { ObservabilityConfig, DEFAULT_OBSERVABILITY_CONFIG, DiagnosticsReport, TraceSpan, DiagnosticEvent } from './types';
+import { ObservabilityConfig, DEFAULT_OBSERVABILITY_CONFIG, DiagnosticsReport, TraceSpan } from './types';
 
 export class ObservabilityService {
   readonly logger: Logger;

--- a/src/observability/observabilityService.ts
+++ b/src/observability/observabilityService.ts
@@ -1,0 +1,55 @@
+﻿import { Logger, LogLevel, CustomLogger } from '../utils/logger';
+import { Tracer } from './tracer';
+import { DiagnosticsManager } from '../diagnostics/diagnosticsManager';
+import { ObservabilityConfig, DEFAULT_OBSERVABILITY_CONFIG, DiagnosticsReport, TraceSpan, DiagnosticEvent } from './types';
+
+export class ObservabilityService {
+  readonly logger: Logger;
+  readonly tracer: Tracer;
+  readonly diagnostics: DiagnosticsManager;
+  private config: ObservabilityConfig;
+
+  constructor(config?: Partial<ObservabilityConfig>, customLogger?: CustomLogger) {
+    this.config = { ...DEFAULT_OBSERVABILITY_CONFIG, ...config };
+    this.logger = new Logger(this.config.logLevel, undefined, customLogger);
+    this.tracer = new Tracer(this.config.traceLevel, this.config.maxSpans);
+    this.diagnostics = new DiagnosticsManager(this.config.diagnosticsEnabled, this.config.maxDiagnosticEvents);
+  }
+
+  updateConfig(updates: Partial<ObservabilityConfig>): void {
+    this.config = { ...this.config, ...updates };
+
+    if (updates.logLevel !== undefined) {
+      (this.logger as any).level = updates.logLevel;
+    }
+    if (updates.traceLevel !== undefined) {
+      this.tracer.setLevel(updates.traceLevel);
+    }
+    if (updates.diagnosticsEnabled !== undefined) {
+      this.diagnostics.setEnabled(updates.diagnosticsEnabled);
+    }
+  }
+
+  getConfig(): ObservabilityConfig {
+    return { ...this.config };
+  }
+
+  getDiagnosticsReport(): DiagnosticsReport {
+    return this.diagnostics.generateReport();
+  }
+
+  getTraces(): TraceSpan[] {
+    return this.tracer.getAllSpans();
+  }
+
+  getActiveTraces(): TraceSpan[] {
+    return this.tracer.getActiveSpans();
+  }
+
+  clear(): void {
+    this.tracer.clear();
+    this.diagnostics.clear();
+  }
+}
+
+export const observabilityService = new ObservabilityService();

--- a/src/observability/tracer.ts
+++ b/src/observability/tracer.ts
@@ -1,0 +1,122 @@
+﻿import { TraceSpan, TraceLevel } from './types';
+
+const TRACE_LEVEL_PRIORITY: Record<TraceLevel, number> = {
+  off: 0,
+  error: 1,
+  warn: 2,
+  info: 3,
+  debug: 4,
+};
+
+export class Tracer {
+  private spans: Map<string, TraceSpan> = new Map();
+  private activeSpans: Map<string, TraceSpan> = new Map();
+  private level: TraceLevel;
+  private maxSpans: number;
+  private spanCounter = 0;
+
+  constructor(level: TraceLevel = 'off', maxSpans = 100) {
+    this.level = level;
+    this.maxSpans = maxSpans;
+  }
+
+  setLevel(level: TraceLevel): void {
+    this.level = level;
+  }
+
+  startSpan(name: string, tags: Record<string, string> = {}, parentId?: string): string {
+    if (this.level === 'off') return '';
+
+    this.spanCounter++;
+    const id = span__;
+
+    const span: TraceSpan = {
+      id,
+      name,
+      startTime: Date.now(),
+      tags,
+      parentId,
+    };
+
+    this.activeSpans.set(id, span);
+
+    if (this.activeSpans.size + this.spans.size > this.maxSpans) {
+      this.evictOldest();
+    }
+
+    return id;
+  }
+
+  endSpan(spanId: string): void {
+    const span = this.activeSpans.get(spanId);
+    if (!span) return;
+
+    span.endTime = Date.now();
+    span.duration = span.endTime - span.startTime;
+    this.activeSpans.delete(spanId);
+    this.spans.set(spanId, span);
+  }
+
+  addTag(spanId: string, key: string, value: string): void {
+    const span = this.activeSpans.get(spanId);
+    if (span) {
+      span.tags[key] = value;
+    }
+  }
+
+  getSpan(spanId: string): TraceSpan | undefined {
+    return this.activeSpans.get(spanId) ?? this.spans.get(spanId);
+  }
+
+  getAllSpans(): TraceSpan[] {
+    return [...this.spans.values()];
+  }
+
+  getActiveSpans(): TraceSpan[] {
+    return [...this.activeSpans.values()];
+  }
+
+  clear(): void {
+    this.spans.clear();
+    this.activeSpans.clear();
+  }
+
+  private evictOldest(): void {
+    let oldest: string | undefined;
+    let oldestTime = Infinity;
+    for (const [id, span] of this.spans) {
+      if (span.startTime < oldestTime) {
+        oldestTime = span.startTime;
+        oldest = id;
+      }
+    }
+    if (oldest) this.spans.delete(oldest);
+  }
+}
+
+export function traceMethod(level: TraceLevel = 'info') {
+  return function (_target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    const original = descriptor.value;
+    descriptor.value = function (...args: any[]) {
+      const tracer: Tracer | undefined = (this as any).__tracer;
+      if (!tracer) return original.apply(this, args);
+
+      const spanId = tracer.startSpan(propertyKey, {
+        args: JSON.stringify(args).slice(0, 200),
+      });
+
+      try {
+        const result = original.apply(this, args);
+        if (result instanceof Promise) {
+          return result.finally(() => tracer.endSpan(spanId));
+        }
+        tracer.endSpan(spanId);
+        return result;
+      } catch (error) {
+        tracer.addTag(spanId, 'error', String(error));
+        tracer.endSpan(spanId);
+        throw error;
+      }
+    };
+  };
+}

--- a/src/observability/tracer.ts
+++ b/src/observability/tracer.ts
@@ -1,12 +1,6 @@
-﻿import { TraceSpan, TraceLevel } from './types';
+import { TraceSpan, TraceLevel } from './types';
 
-const TRACE_LEVEL_PRIORITY: Record<TraceLevel, number> = {
-  off: 0,
-  error: 1,
-  warn: 2,
-  info: 3,
-  debug: 4,
-};
+
 
 export class Tracer {
   private spans: Map<string, TraceSpan> = new Map();

--- a/src/observability/types.ts
+++ b/src/observability/types.ts
@@ -1,0 +1,51 @@
+﻿import type { LogLevel } from '../utils/logger';
+
+export type TraceLevel = 'off' | 'error' | 'warn' | 'info' | 'debug';
+
+export interface TraceSpan {
+  id: string;
+  name: string;
+  startTime: number;
+  endTime?: number;
+  duration?: number;
+  tags: Record<string, string>;
+  parentId?: string;
+}
+
+export interface DiagnosticEvent {
+  id: string;
+  type: string;
+  timestamp: number;
+  data: Record<string, any>;
+}
+
+export interface ObservabilityConfig {
+  logLevel: LogLevel;
+  traceLevel: TraceLevel;
+  diagnosticsEnabled: boolean;
+  traceEnabled: boolean;
+  /** Max number of spans to keep in memory */
+  maxSpans: number;
+  /** Max number of diagnostic events to keep */
+  maxDiagnosticEvents: number;
+}
+
+export const DEFAULT_OBSERVABILITY_CONFIG: ObservabilityConfig = {
+  logLevel: 'none',
+  traceLevel: 'off',
+  diagnosticsEnabled: false,
+  traceEnabled: false,
+  maxSpans: 100,
+  maxDiagnosticEvents: 500,
+};
+
+export interface DiagnosticsReport {
+  timestamp: number;
+  events: DiagnosticEvent[];
+  summary: {
+    totalEvents: number;
+    byType: Record<string, number>;
+    errors: number;
+    warnings: number;
+  };
+}

--- a/tests/observability/diagnostics.test.ts
+++ b/tests/observability/diagnostics.test.ts
@@ -1,0 +1,78 @@
+﻿import { DiagnosticsManager } from '../../src/diagnostics/diagnosticsManager';
+
+describe('DiagnosticsManager', () => {
+  let diag: DiagnosticsManager;
+
+  beforeEach(() => {
+    diag = new DiagnosticsManager(true, 100);
+  });
+
+  it('records diagnostic events when enabled', () => {
+    diag.record('rpc_call', { url: 'https://rpc.example.com' });
+    diag.record('rpc_response', { status: 200 });
+
+    expect(diag.getEventCount()).toBe(2);
+  });
+
+  it('does not record when disabled', () => {
+    diag.setEnabled(false);
+    diag.record('test', {});
+    expect(diag.getEventCount()).toBe(0);
+  });
+
+  it('generates a report with summary', () => {
+    diag.record('error_connect', { msg: 'timeout' });
+    diag.record('error_auth', { msg: 'unauthorized' });
+    diag.record('warn_retry', { attempt: 1 });
+    diag.record('info_start', {});
+
+    const report = diag.generateReport();
+    expect(report.summary.totalEvents).toBe(4);
+    expect(report.summary.errors).toBe(2);
+    expect(report.summary.warnings).toBe(1);
+    expect(report.summary.byType['error_connect']).toBe(1);
+  });
+
+  it('filters events by type', () => {
+    diag.record('error', {});
+    diag.record('info', {});
+    diag.record('error', {});
+
+    const errors = diag.getEvents({ type: 'error' });
+    expect(errors).toHaveLength(2);
+  });
+
+  it('filters events by timestamp', () => {
+    diag.record('old', {});
+    const now = Date.now();
+    diag.record('new', {});
+
+    const recent = diag.getEvents({ since: now });
+    expect(recent).toHaveLength(1);
+    expect(recent[0].type).toBe('new');
+  });
+
+  it('emits events to listeners', () => {
+    const received: any[] = [];
+    diag.onDiagnosticEvent((e) => received.push(e));
+    diag.record('test', { value: 42 });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].data.value).toBe(42);
+  });
+
+  it('unsubscribes listeners', () => {
+    const received: any[] = [];
+    const unsub = diag.onDiagnosticEvent((e) => received.push(e));
+    unsub();
+    diag.record('test', {});
+    expect(received).toHaveLength(0);
+  });
+
+  it('clears all events', () => {
+    diag.record('a', {});
+    diag.record('b', {});
+    diag.clear();
+    expect(diag.getEventCount()).toBe(0);
+  });
+});

--- a/tests/observability/tracer.test.ts
+++ b/tests/observability/tracer.test.ts
@@ -1,0 +1,68 @@
+﻿import { Tracer } from '../../src/observability/tracer';
+
+describe('Tracer', () => {
+  let tracer: Tracer;
+
+  beforeEach(() => {
+    tracer = new Tracer('debug', 50);
+  });
+
+  it('starts and ends a span', () => {
+    const id = tracer.startSpan('test_op');
+    expect(id).toBeTruthy();
+    expect(tracer.getActiveSpans()).toHaveLength(1);
+
+    tracer.endSpan(id);
+    expect(tracer.getActiveSpans()).toHaveLength(0);
+    expect(tracer.getAllSpans()).toHaveLength(1);
+  });
+
+  it('records span duration', () => {
+    const id = tracer.startSpan('timed_op');
+    tracer.endSpan(id);
+
+    const span = tracer.getSpan(id);
+    expect(span?.duration).toBeGreaterThanOrEqual(0);
+  });
+
+  it('adds tags to span', () => {
+    const id = tracer.startSpan('tagged_op');
+    tracer.addTag(id, 'key', 'value');
+    tracer.addTag(id, 'status', 'ok');
+    tracer.endSpan(id);
+
+    const span = tracer.getSpan(id);
+    expect(span?.tags.key).toBe('value');
+    expect(span?.tags.status).toBe('ok');
+  });
+
+  it('returns undefined for unknown span', () => {
+    expect(tracer.getSpan('nonexistent')).toBeUndefined();
+  });
+
+  it('does not create spans when level is off', () => {
+    tracer.setLevel('off');
+    const id = tracer.startSpan('off_op');
+    expect(id).toBe('');
+    expect(tracer.getActiveSpans()).toHaveLength(0);
+  });
+
+  it('evicts oldest spans when over capacity', () => {
+    const smallTracer = new Tracer('debug', 3);
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const id = smallTracer.startSpan(op_);
+      smallTracer.endSpan(id);
+      ids.push(id);
+    }
+    expect(smallTracer.getAllSpans()).toHaveLength(3);
+  });
+
+  it('clears all spans', () => {
+    tracer.startSpan('op1');
+    tracer.startSpan('op2');
+    tracer.clear();
+    expect(tracer.getActiveSpans()).toHaveLength(0);
+    expect(tracer.getAllSpans()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #240

 Summary
Creates an observability framework providing logging, tracing, diagnostics, and debugging capabilities for the SDK.

 Files Created (8 files, 473 lines)

 src/observability/
- `types.ts` — TraceSpan, DiagnosticEvent, ObservabilityConfig, DiagnosticsReport
- `tracer.ts` — Tracer class with span management, tags, eviction, and traceMethod decorator
- `observabilityService.ts` — Unified service wrapping Logger, Tracer, and DiagnosticsManager
- `index.ts` — Barrel export

 src/diagnostics/
- `diagnosticsManager.ts` — Event recording, filtering, listener subscription, report generation
- `index.ts` — Barrel export

 tests/observability/
- `tracer.test.ts` — 7 tests covering span lifecycle, tags, off mode, eviction, clear
- `diagnostics.test.ts` — 8 tests covering recording, enable/disable, reports, filtering, listeners

 Features
- Span-based tracing with tags and duration tracking
- Diagnostic event recording with type filtering and timestamp queries
- Real-time diagnostic event listeners
- Configurable log levels, trace levels, and diagnostic toggles
- Automatic span eviction when over capacity
- traceMethod decorator for automatic method tracing
- DiagnosticsReport generation with summary statistics