### PR TITLE
feat: add telemetry infrastructure with metrics and privacy controls

### DIFF
--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,0 +1,1 @@
+﻿export * from './metricsCollector';

--- a/src/metrics/metricsCollector.ts
+++ b/src/metrics/metricsCollector.ts
@@ -55,9 +55,9 @@ export class MetricsCollector {
 
   private key(name: string, tags: Record<string, string>): string {
     const tagStr = Object.entries(tags)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([k, v]) => ${k}=)
+      .sort(([a], [b]) =&gt; a.localeCompare(b))
+      .map(([k, v]) =&gt; k + '=' + v)
       .join(',');
-    return tagStr ? ${name}[] : name;
+    return tagStr ? name + '[' + tagStr + ']' : name;
   }
 }

--- a/src/metrics/metricsCollector.ts
+++ b/src/metrics/metricsCollector.ts
@@ -1,0 +1,63 @@
+﻿import { MetricCounter, MetricGauge, MetricHistogram, MetricsSnapshot } from '../telemetry/types';
+
+export class MetricsCollector {
+  private counters: Map<string, MetricCounter> = new Map();
+  private gauges: Map<string, MetricGauge> = new Map();
+  private histograms: Map<string, MetricHistogram> = new Map();
+
+  increment(name: string, tags: Record<string, string> = {}, value = 1): void {
+    const key = this.key(name, tags);
+    const existing = this.counters.get(key);
+    if (existing) {
+      existing.value += value;
+    } else {
+      this.counters.set(key, { name, value, tags });
+    }
+  }
+
+  gauge(name: string, value: number, tags: Record<string, string> = {}): void {
+    const key = this.key(name, tags);
+    this.gauges.set(key, { name, value, tags });
+  }
+
+  observe(name: string, value: number, tags: Record<string, string> = {}, buckets: number[] = [1, 5, 10, 50, 100, 500, 1000]): void {
+    const key = this.key(name, tags);
+    const existing = this.histograms.get(key);
+    if (existing) {
+      existing.values.push(value);
+    } else {
+      this.histograms.set(key, { name, values: [value], tags, buckets });
+    }
+  }
+
+  getCounter(name: string, tags: Record<string, string> = {}): MetricCounter | undefined {
+    return this.counters.get(this.key(name, tags));
+  }
+
+  getGauge(name: string, tags: Record<string, string> = {}): MetricGauge | undefined {
+    return this.gauges.get(this.key(name, tags));
+  }
+
+  snapshot(): MetricsSnapshot {
+    return {
+      timestamp: Date.now(),
+      counters: [...this.counters.values()],
+      gauges: [...this.gauges.values()],
+      histograms: [...this.histograms.values()],
+    };
+  }
+
+  clear(): void {
+    this.counters.clear();
+    this.gauges.clear();
+    this.histograms.clear();
+  }
+
+  private key(name: string, tags: Record<string, string>): string {
+    const tagStr = Object.entries(tags)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => ${k}=)
+      .join(',');
+    return tagStr ? ${name}[] : name;
+  }
+}

--- a/src/metrics/metricsCollector.ts
+++ b/src/metrics/metricsCollector.ts
@@ -1,4 +1,4 @@
-﻿import { MetricCounter, MetricGauge, MetricHistogram, MetricsSnapshot } from '../telemetry/types';
+import { MetricCounter, MetricGauge, MetricHistogram, MetricsSnapshot } from '../telemetry/types';
 
 export class MetricsCollector {
   private counters: Map<string, MetricCounter> = new Map();
@@ -55,8 +55,8 @@ export class MetricsCollector {
 
   private key(name: string, tags: Record<string, string>): string {
     const tagStr = Object.entries(tags)
-      .sort(([a], [b]) =&gt; a.localeCompare(b))
-      .map(([k, v]) =&gt; k + '=' + v)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => k + '=' + v)
       .join(',');
     return tagStr ? name + '[' + tagStr + ']' : name;
   }

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,2 @@
+﻿export * from './types';
+export * from './telemetryService';

--- a/src/telemetry/telemetryService.ts
+++ b/src/telemetry/telemetryService.ts
@@ -1,0 +1,125 @@
+﻿import { TelemetryConfig, TelemetryEvent, DEFAULT_TELEMETRY_CONFIG, MetricsSnapshot } from './types';
+import { MetricsCollector } from '../metrics/metricsCollector';
+
+export type TelemetryFlushHandler = (events: TelemetryEvent[], snapshot: MetricsSnapshot) => void | Promise<void>;
+
+export class TelemetryService {
+  private config: TelemetryConfig;
+  private events: TelemetryEvent[] = [];
+  private metrics: MetricsCollector = new MetricsCollector();
+  private flushTimer: ReturnType<typeof setInterval> | null = null;
+  private flushHandler: TelemetryFlushHandler | null = null;
+  private eventCounter = 0;
+
+  constructor(config?: Partial<TelemetryConfig>) {
+    this.config = { ...DEFAULT_TELEMETRY_CONFIG, ...config };
+    if (this.config.enabled) {
+      this.startFlushTimer();
+    }
+  }
+
+  setEnabled(enabled: boolean): void {
+    this.config.enabled = enabled;
+    if (enabled) {
+      this.startFlushTimer();
+    } else {
+      this.stopFlushTimer();
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.config.enabled;
+  }
+
+  onFlush(handler: TelemetryFlushHandler): void {
+    this.flushHandler = handler;
+  }
+
+  track(type: string, data: Record<string, any> = {}): void {
+    if (!this.config.enabled) return;
+
+    this.eventCounter++;
+    const event: TelemetryEvent = {
+      id: 	el__,
+      type,
+      timestamp: Date.now(),
+      data: this.config.anonymize ? this.anonymize(data) : data,
+      anonymized: this.config.anonymize,
+    };
+
+    this.events.push(event);
+
+    if (this.events.length >= this.config.bufferSize) {
+      this.flush();
+    }
+  }
+
+  metrics(): MetricsCollector {
+    return this.metrics;
+  }
+
+  getConfig(): TelemetryConfig {
+    return { ...this.config };
+  }
+
+  updateConfig(updates: Partial<TelemetryConfig>): void {
+    const wasEnabled = this.config.enabled;
+    this.config = { ...this.config, ...updates };
+
+    if (!wasEnabled && this.config.enabled) {
+      this.startFlushTimer();
+    } else if (wasEnabled && !this.config.enabled) {
+      this.stopFlushTimer();
+      this.flush();
+    }
+  }
+
+  flush(): void {
+    if (this.events.length === 0) return;
+
+    const events = this.events.splice(0);
+    const snapshot = this.metrics.snapshot();
+
+    if (this.flushHandler) {
+      try {
+        const result = this.flushHandler(events, snapshot);
+        if (result instanceof Promise) {
+          result.catch(() => {});
+        }
+      } catch {}
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.stopFlushTimer();
+    this.flush();
+    this.metrics.clear();
+  }
+
+  private startFlushTimer(): void {
+    this.stopFlushTimer();
+    this.flushTimer = setInterval(() => this.flush(), this.config.flushIntervalMs);
+  }
+
+  private stopFlushTimer(): void {
+    if (this.flushTimer) {
+      clearInterval(this.flushTimer);
+      this.flushTimer = null;
+    }
+  }
+
+  private anonymize(data: Record<string, any>): Record<string, any> {
+    const sensitiveKeys = ['address', 'publicKey', 'email', 'userId', 'account'];
+    const result: Record<string, any> = {};
+    for (const [key, value] of Object.entries(data)) {
+      if (sensitiveKeys.some((k) => key.toLowerCase().includes(k.toLowerCase()))) {
+        result[key] = '[REDACTED]';
+      } else if (typeof value === 'object' && value !== null) {
+        result[key] = this.anonymize(value);
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+}

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,0 +1,55 @@
+﻿export interface TelemetryConfig {
+  enabled: boolean;
+  /** Anonymize all collected data */
+  anonymize: boolean;
+  /** Maximum number of events to buffer before flush */
+  bufferSize: number;
+  /** Auto-flush interval in milliseconds */
+  flushIntervalMs: number;
+  /** Application identifier for multi-app deployments */
+  appId?: string;
+  /** SDK version for version-aware metrics */
+  sdkVersion?: string;
+}
+
+export const DEFAULT_TELEMETRY_CONFIG: TelemetryConfig = {
+  enabled: false,
+  anonymize: true,
+  bufferSize: 50,
+  flushIntervalMs: 30000,
+};
+
+export interface TelemetryEvent {
+  id: string;
+  type: string;
+  timestamp: number;
+  data: Record<string, any>;
+  /** Whether the event has been anonymized */
+  anonymized: boolean;
+}
+
+export interface MetricCounter {
+  name: string;
+  value: number;
+  tags: Record<string, string>;
+}
+
+export interface MetricGauge {
+  name: string;
+  value: number;
+  tags: Record<string, string>;
+}
+
+export interface MetricHistogram {
+  name: string;
+  values: number[];
+  tags: Record<string, string>;
+  buckets: number[];
+}
+
+export interface MetricsSnapshot {
+  timestamp: number;
+  counters: MetricCounter[];
+  gauges: MetricGauge[];
+  histograms: MetricHistogram[];
+}

--- a/tests/telemetry/metricsCollector.test.ts
+++ b/tests/telemetry/metricsCollector.test.ts
@@ -1,0 +1,67 @@
+﻿import { MetricsCollector } from '../../src/metrics/metricsCollector';
+
+describe('MetricsCollector', () => {
+  let collector: MetricsCollector;
+
+  beforeEach(() => {
+    collector = new MetricsCollector();
+  });
+
+  it('increments counters', () => {
+    collector.increment('rpc_calls');
+    collector.increment('rpc_calls');
+    collector.increment('rpc_calls', {}, 3);
+
+    const counter = collector.getCounter('rpc_calls');
+    expect(counter?.value).toBe(5);
+  });
+
+  it('tracks counters with tags separately', () => {
+    collector.increment('api_calls', { endpoint: '/health' });
+    collector.increment('api_calls', { endpoint: '/balance' }, 2);
+
+    const health = collector.getCounter('api_calls', { endpoint: '/health' });
+    const balance = collector.getCounter('api_calls', { endpoint: '/balance' });
+
+    expect(health?.value).toBe(1);
+    expect(balance?.value).toBe(2);
+  });
+
+  it('sets and gets gauges', () => {
+    collector.gauge('active_connections', 5);
+    collector.gauge('active_connections', 8);
+
+    const gauge = collector.getGauge('active_connections');
+    expect(gauge?.value).toBe(8);
+  });
+
+  it('records histogram values', () => {
+    collector.observe('tx_latency', 12);
+    collector.observe('tx_latency', 45);
+    collector.observe('tx_latency', 7);
+
+    const snapshot = collector.snapshot();
+    const hist = snapshot.histograms.find((h) => h.name === 'tx_latency');
+    expect(hist?.values).toEqual([12, 45, 7]);
+  });
+
+  it('produces a snapshot with all metric types', () => {
+    collector.increment('errors', {}, 3);
+    collector.gauge('memory_mb', 256);
+    collector.observe('latency', 50);
+
+    const snapshot = collector.snapshot();
+    expect(snapshot.counters).toHaveLength(1);
+    expect(snapshot.gauges).toHaveLength(1);
+    expect(snapshot.histograms).toHaveLength(1);
+  });
+
+  it('clears all metrics', () => {
+    collector.increment('test', {}, 5);
+    collector.gauge('test_gauge', 10);
+    collector.clear();
+
+    expect(collector.getCounter('test')).toBeUndefined();
+    expect(collector.getGauge('test_gauge')).toBeUndefined();
+  });
+});

--- a/tests/telemetry/telemetryService.test.ts
+++ b/tests/telemetry/telemetryService.test.ts
@@ -1,0 +1,93 @@
+﻿import { TelemetryService, TelemetryFlushHandler } from '../../src/telemetry/telemetryService';
+import { TelemetryEvent, MetricsSnapshot } from '../../src/telemetry/types';
+
+describe('TelemetryService', () => {
+  let telemetry: TelemetryService;
+
+  beforeEach(() => {
+    telemetry = new TelemetryService({ enabled: true, anonymize: false, bufferSize: 5, flushIntervalMs: 60000 });
+  });
+
+  afterEach(() => {
+    telemetry.destroy();
+  });
+
+  it('tracks events when enabled', () => {
+    telemetry.track('sdk_init', { version: '1.0.0' });
+    telemetry.track('wallet_connect');
+
+    const flushed: TelemetryEvent[] = [];
+    telemetry.onFlush((events) => flushed.push(...events));
+    telemetry.flush();
+
+    expect(flushed).toHaveLength(2);
+    expect(flushed[0].type).toBe('sdk_init');
+  });
+
+  it('does not track when disabled', () => {
+    telemetry.setEnabled(false);
+    telemetry.track('test', {});
+
+    const flushed: TelemetryEvent[] = [];
+    telemetry.onFlush((events) => flushed.push(...events));
+    telemetry.flush();
+
+    expect(flushed).toHaveLength(0);
+  });
+
+  it('auto-flushes when buffer is full', () => {
+    const flushed: TelemetryEvent[] = [];
+    telemetry.onFlush((events) => flushed.push(...events));
+
+    for (let i = 0; i < 5; i++) {
+      telemetry.track('event', { index: i });
+    }
+
+    expect(flushed).toHaveLength(5);
+  });
+
+  it('anonymizes sensitive data when enabled', () => {
+    const privateTelemetry = new TelemetryService({ enabled: true, anonymize: true });
+    privateTelemetry.track('login', { address: 'GABC123', email: 'user@test.com', action: 'connect' });
+
+    const flushed: TelemetryEvent[] = [];
+    privateTelemetry.onFlush((events) => flushed.push(...events));
+    privateTelemetry.flush();
+
+    expect(flushed[0].data.address).toBe('[REDACTED]');
+    expect(flushed[0].data.email).toBe('[REDACTED]');
+    expect(flushed[0].data.action).toBe('connect');
+    expect(flushed[0].anonymized).toBe(true);
+
+    privateTelemetry.destroy();
+  });
+
+  it('calls flush handler on manual flush', () => {
+    let called = false;
+    telemetry.onFlush(() => { called = true; });
+    telemetry.track('test', {});
+    telemetry.flush();
+
+    expect(called).toBe(true);
+  });
+
+  it('provides metrics collector', () => {
+    telemetry.metrics().increment('rpc_calls');
+    expect(telemetry.metrics().getCounter('rpc_calls')?.value).toBe(1);
+  });
+
+  it('updates config at runtime', () => {
+    expect(telemetry.isEnabled()).toBe(true);
+    telemetry.updateConfig({ enabled: false });
+    expect(telemetry.isEnabled()).toBe(false);
+  });
+
+  it('flushes on destroy', () => {
+    const flushed: TelemetryEvent[] = [];
+    telemetry.onFlush((events) => flushed.push(...events));
+    telemetry.track('final', {});
+    telemetry.destroy();
+
+    expect(flushed).toHaveLength(1);
+  });
+});

--- a/tests/telemetry/telemetryService.test.ts
+++ b/tests/telemetry/telemetryService.test.ts
@@ -1,5 +1,5 @@
-﻿import { TelemetryService, TelemetryFlushHandler } from '../../src/telemetry/telemetryService';
-import { TelemetryEvent, MetricsSnapshot } from '../../src/telemetry/types';
+﻿import { TelemetryService } from '../../src/telemetry/telemetryService';
+import { TelemetryEvent } from '../../src/telemetry/types';
 
 describe('TelemetryService', () => {
   let telemetry: TelemetryService;


### PR DESCRIPTION
Closes #235

Opt-in telemetry framework providing usage metrics and operational insights with privacy-first design.

 Files (7 files, 406 lines)

 src/telemetry/
- `types.ts` — TelemetryConfig, TelemetryEvent, MetricCounter/Gauge/Histogram, MetricsSnapshot
- `telemetryService.ts` — Event tracking, buffer management, auto-flush, data anonymization, runtime enable/disable

 src/metrics/
- `metricsCollector.ts` — Counters, gauges, histograms with tag-based keying and snapshot export

 tests/telemetry/
- `metricsCollector.test.ts` — 6 tests for counters, gauges, histograms, snapshots, clears
- `telemetryService.test.ts` — 8 tests for tracking, enable/disable, flush, anonymization, destroy

 Features
- Opt-in only — disabled by default
- Event buffering with configurable auto-flush
- Counters, gauges, and histograms with tag support
- Data anonymization for sensitive fields (address, publicKey, email, userId, account)
- Runtime enable/disable and config updates
- Flush handler for custom export