### PR TITLE
Smart contract discovery

### DIFF
--- a/src/discovery/contractDiscovery.ts
+++ b/src/discovery/contractDiscovery.ts
@@ -1,0 +1,38 @@
+import { CapabilityRegistry } from '../registry/capabilityRegistry';
+import { DefaultContractDescriptors } from './defaultContracts';
+import type {
+  ContractCapability,
+  ContractDescriptor,
+  ContractDiscoveryService,
+  DiscoveryValidationResult,
+} from './types';
+
+export class DefaultContractDiscoveryService implements ContractDiscoveryService {
+  private readonly registry: CapabilityRegistry;
+
+  constructor(descriptors: ContractDescriptor[] = DefaultContractDescriptors) {
+    this.registry = new CapabilityRegistry(descriptors);
+  }
+
+  discoverContracts(): ContractDescriptor[] {
+    return this.registry.list();
+  }
+
+  lookupContract(typeOrId: string): ContractDescriptor | undefined {
+    return this.registry.lookup(typeOrId);
+  }
+
+  getCapabilities(typeOrId: string): ContractCapability[] {
+    return this.registry.getCapabilities(typeOrId);
+  }
+
+  supportsCapability(typeOrId: string, capability: ContractCapability): boolean {
+    return this.registry.supportsCapability(typeOrId, capability);
+  }
+
+  validateContract(descriptor: ContractDescriptor): DiscoveryValidationResult {
+    return this.registry.validate(descriptor);
+  }
+}
+
+export const contractDiscovery = new DefaultContractDiscoveryService();

--- a/src/discovery/defaultContracts.ts
+++ b/src/discovery/defaultContracts.ts
@@ -1,0 +1,71 @@
+import type { ContractDescriptor } from './types';
+
+export const VaultContractDescriptor: ContractDescriptor = {
+  type: 'vault',
+  displayName: 'Axionvera Vault',
+  version: '1.0.0',
+  capabilities: [
+    'balance:read',
+    'assets:read',
+    'shares:convert',
+    'assets:deposit',
+    'assets:withdraw',
+    'rewards:read',
+    'rewards:claim',
+  ],
+  methods: [
+    {
+      name: 'getBalance',
+      capability: 'balance:read',
+      mutability: 'view',
+      description: 'Read vault share balance for an account.',
+    },
+    {
+      name: 'getAssetsBalance',
+      capability: 'assets:read',
+      mutability: 'view',
+      description: 'Read the asset-denominated vault balance.',
+    },
+    {
+      name: 'convertToAssets',
+      capability: 'shares:convert',
+      mutability: 'view',
+      description: 'Convert vault shares to assets.',
+    },
+    {
+      name: 'convertToShares',
+      capability: 'shares:convert',
+      mutability: 'view',
+      description: 'Convert assets to vault shares.',
+    },
+    {
+      name: 'deposit',
+      capability: 'assets:deposit',
+      mutability: 'payable',
+      description: 'Deposit assets into the vault.',
+    },
+    {
+      name: 'withdraw',
+      capability: 'assets:withdraw',
+      mutability: 'nonpayable',
+      description: 'Withdraw assets from the vault.',
+    },
+    {
+      name: 'pendingRewards',
+      capability: 'rewards:read',
+      mutability: 'view',
+      description: 'Read pending rewards for an account.',
+    },
+    {
+      name: 'claimRewards',
+      capability: 'rewards:claim',
+      mutability: 'nonpayable',
+      description: 'Claim accrued vault rewards.',
+    },
+  ],
+  metadata: {
+    abi: 'VaultABI',
+  },
+};
+
+export const DefaultContractDescriptors: ContractDescriptor[] = [VaultContractDescriptor];

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,0 +1,9 @@
+export { DefaultContractDiscoveryService, contractDiscovery } from './contractDiscovery';
+export { DefaultContractDescriptors, VaultContractDescriptor } from './defaultContracts';
+export type {
+  ContractCapability,
+  ContractDescriptor,
+  ContractDiscoveryService,
+  ContractMethodDescriptor,
+  DiscoveryValidationResult,
+} from './types';

--- a/src/discovery/types.ts
+++ b/src/discovery/types.ts
@@ -1,0 +1,41 @@
+/** Supported smart contract capability identifiers. */
+export type ContractCapability =
+  | 'balance:read'
+  | 'assets:read'
+  | 'shares:convert'
+  | 'assets:deposit'
+  | 'assets:withdraw'
+  | 'rewards:claim'
+  | 'rewards:read';
+
+/** A single callable contract method exposed through discovery metadata. */
+export interface ContractMethodDescriptor {
+  name: string;
+  capability: ContractCapability;
+  mutability: 'view' | 'payable' | 'nonpayable';
+  description: string;
+}
+
+/** Discovery metadata for a supported smart contract type. */
+export interface ContractDescriptor {
+  type: string;
+  displayName: string;
+  version: string;
+  contractId?: string;
+  capabilities: ContractCapability[];
+  methods: ContractMethodDescriptor[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface DiscoveryValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export interface ContractDiscoveryService {
+  discoverContracts(): ContractDescriptor[];
+  lookupContract(typeOrId: string): ContractDescriptor | undefined;
+  getCapabilities(typeOrId: string): ContractCapability[];
+  supportsCapability(typeOrId: string, capability: ContractCapability): boolean;
+  validateContract(descriptor: ContractDescriptor): DiscoveryValidationResult;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,12 @@ export { Vault } from './contracts/vault';
 export { VaultABI } from './contracts/abis/VaultABI';
 export type { VaultConfig, DepositParams, WithdrawParams, VaultInfo } from './contracts/vault';
 
+
+// Discovery
+export { DefaultContractDiscoveryService, contractDiscovery, DefaultContractDescriptors, VaultContractDescriptor } from './discovery';
+export { CapabilityRegistry } from './registry';
+export type { ContractCapability, ContractDescriptor, ContractDiscoveryService, ContractMethodDescriptor, DiscoveryValidationResult } from './discovery';
+
 // Wallet
 export { LocalKeypairWalletConnector } from './wallet/walletConnector';
 export { LocalKeypairWalletConnector, MockWalletConnector } from './wallet/walletConnector';

--- a/src/registry/capabilityRegistry.ts
+++ b/src/registry/capabilityRegistry.ts
@@ -1,0 +1,96 @@
+import { ValidationError } from '../errors/axionveraError';
+import type {
+  ContractCapability,
+  ContractDescriptor,
+  DiscoveryValidationResult,
+} from '../discovery/types';
+
+const CONTRACT_ID_PATTERN = /^(0x[a-fA-F0-9]{40}|[A-Z0-9]{56}|[a-fA-F0-9]{64})$/;
+
+const unique = <T>(values: T[]): T[] => Array.from(new Set(values));
+
+export class CapabilityRegistry {
+  private readonly contracts = new Map<string, ContractDescriptor>();
+
+  constructor(descriptors: ContractDescriptor[] = []) {
+    descriptors.forEach((descriptor) => this.register(descriptor));
+  }
+
+  register(descriptor: ContractDescriptor): ContractDescriptor {
+    const validation = this.validate(descriptor);
+    if (!validation.valid) {
+      throw new ValidationError(`Invalid contract descriptor: ${validation.errors.join('; ')}`);
+    }
+
+    const normalized = this.normalize(descriptor);
+    this.contracts.set(normalized.type, normalized);
+    if (normalized.contractId) {
+      this.contracts.set(normalized.contractId, normalized);
+    }
+    return normalized;
+  }
+
+  list(): ContractDescriptor[] {
+    return unique(Array.from(this.contracts.values())).map((descriptor) => ({
+      ...descriptor,
+      capabilities: [...descriptor.capabilities],
+      methods: descriptor.methods.map((method) => ({ ...method })),
+      metadata: descriptor.metadata ? { ...descriptor.metadata } : undefined,
+    }));
+  }
+
+  lookup(typeOrId: string): ContractDescriptor | undefined {
+    const descriptor = this.contracts.get(typeOrId);
+    return descriptor
+      ? {
+          ...descriptor,
+          capabilities: [...descriptor.capabilities],
+          methods: descriptor.methods.map((method) => ({ ...method })),
+          metadata: descriptor.metadata ? { ...descriptor.metadata } : undefined,
+        }
+      : undefined;
+  }
+
+  getCapabilities(typeOrId: string): ContractCapability[] {
+    return this.lookup(typeOrId)?.capabilities ?? [];
+  }
+
+  supportsCapability(typeOrId: string, capability: ContractCapability): boolean {
+    return this.getCapabilities(typeOrId).includes(capability);
+  }
+
+  validate(descriptor: ContractDescriptor): DiscoveryValidationResult {
+    const errors: string[] = [];
+    if (!descriptor.type?.trim()) errors.push('type is required');
+    if (!descriptor.displayName?.trim()) errors.push('displayName is required');
+    if (!descriptor.version?.trim()) errors.push('version is required');
+    if (descriptor.contractId && !CONTRACT_ID_PATTERN.test(descriptor.contractId)) {
+      errors.push('contractId must be a valid EVM, Soroban, or 32-byte hex identifier');
+    }
+    if (!descriptor.capabilities?.length) errors.push('at least one capability is required');
+    if (!descriptor.methods?.length) errors.push('at least one method is required');
+
+    const capabilities = new Set(descriptor.capabilities ?? []);
+    for (const method of descriptor.methods ?? []) {
+      if (!method.name?.trim()) errors.push('method name is required');
+      if (!capabilities.has(method.capability)) {
+        errors.push(`method ${method.name} references unsupported capability ${method.capability}`);
+      }
+    }
+
+    return { valid: errors.length === 0, errors };
+  }
+
+  private normalize(descriptor: ContractDescriptor): ContractDescriptor {
+    return {
+      ...descriptor,
+      type: descriptor.type.trim(),
+      displayName: descriptor.displayName.trim(),
+      version: descriptor.version.trim(),
+      contractId: descriptor.contractId?.trim(),
+      capabilities: unique(descriptor.capabilities),
+      methods: descriptor.methods.map((method) => ({ ...method })),
+      metadata: descriptor.metadata ? { ...descriptor.metadata } : undefined,
+    };
+  }
+}

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -1,0 +1,1 @@
+export { CapabilityRegistry } from './capabilityRegistry';

--- a/tests/discovery/contractDiscovery.test.ts
+++ b/tests/discovery/contractDiscovery.test.ts
@@ -1,0 +1,66 @@
+import { DefaultContractDiscoveryService, contractDiscovery } from '../../src/discovery';
+import { VaultContractDescriptor } from '../../src/discovery/defaultContracts';
+import { CapabilityRegistry } from '../../src/registry';
+import { ValidationError } from '../../src/errors/axionveraError';
+
+describe('smart contract discovery', () => {
+  test('discovers default supported contracts dynamically', () => {
+    const contracts = contractDiscovery.discoverContracts();
+
+    expect(contracts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'vault',
+          displayName: 'Axionvera Vault',
+          capabilities: expect.arrayContaining([
+            'assets:deposit',
+            'assets:withdraw',
+            'rewards:claim',
+          ]),
+        }),
+      ])
+    );
+  });
+
+  test('looks up capabilities and methods by contract type', () => {
+    const service = new DefaultContractDiscoveryService();
+
+    expect(service.supportsCapability('vault', 'shares:convert')).toBe(true);
+    expect(service.supportsCapability('vault', 'rewards:claim')).toBe(true);
+    expect(service.lookupContract('vault')?.methods.map((method) => method.name)).toEqual(
+      expect.arrayContaining(['deposit', 'withdraw', 'convertToAssets', 'claimRewards'])
+    );
+  });
+
+  test('registers and discovers a contract by concrete contract id', () => {
+    const contractId = '0x1111111111111111111111111111111111111111';
+    const registry = new CapabilityRegistry([{ ...VaultContractDescriptor, contractId }]);
+
+    expect(registry.lookup(contractId)?.type).toBe('vault');
+    expect(registry.getCapabilities(contractId)).toContain('assets:deposit');
+  });
+
+  test('validates descriptor schema before registration', () => {
+    const service = new DefaultContractDiscoveryService();
+    const validation = service.validateContract({
+      ...VaultContractDescriptor,
+      contractId: 'not-a-contract-id',
+      capabilities: ['balance:read'],
+      methods: [{ ...VaultContractDescriptor.methods[0], capability: 'assets:withdraw' }],
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.errors).toEqual(
+      expect.arrayContaining([
+        'contractId must be a valid EVM, Soroban, or 32-byte hex identifier',
+        'method getBalance references unsupported capability assets:withdraw',
+      ])
+    );
+  });
+
+  test('throws a validation error for invalid registration', () => {
+    expect(
+      () => new CapabilityRegistry([{ ...VaultContractDescriptor, capabilities: [] }])
+    ).toThrow(ValidationError);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",


### PR DESCRIPTION
Motivation
Provide a programmatic discovery layer so applications can enumerate supported contracts and their capabilities instead of relying on hardcoded assumptions.
Surface contract method-level metadata and runtime validation so clients can query capabilities and safely register custom descriptors.
Ship a small, composable API (registry + discovery service + default descriptors) that can be reused across consumers.
Description
Added typed discovery primitives in src/discovery/types.ts describing capabilities, method descriptors, contract descriptors, validation results, and the discovery service interface.
Implemented CapabilityRegistry in src/registry/capabilityRegistry.ts to register/normalize/validate descriptors, list contracts, lookup by type or concrete contract ID, query capabilities, and check support for a capability.
Added default Vault metadata in src/discovery/defaultContracts.ts and a DefaultContractDiscoveryService (plus singleton contractDiscovery) in src/discovery/contractDiscovery.ts that delegates storage and validation to the registry; re-exported APIs from src/index.ts.
Added unit tests in tests/discovery/contractDiscovery.test.ts covering discovery of defaults, capability/method lookups, concrete ID registration, validation errors, and invalid registration; adjusted tsconfig.json ignoreDeprecations setting to run the local TypeScript version during tests.
Testing
Ran the discovery unit tests with npm test -- --runTestsByPath tests/discovery/contractDiscovery.test.ts --coverage=false and all tests passed (5 tests, 0 failures).
Performed a TypeScript check with npx tsc --noEmit --target ES2020 --module CommonJS --moduleResolution Node --esModuleInterop --skipLibCheck src/discovery/index.ts src/registry/index.ts tests/discovery/contractDiscovery.test.ts which completed successfully.
Closes https://github.com/Axionvera/axionvera-sdk/issues/230