### PR TITLE
Contract call profiling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,11 @@ export { parseEvents, decodeSorobanSymbol } from './utils/soroban';
 export type { ParsedEvent, ParseEventsOptions, DecodedTopic } from './utils/soroban';
 export { isValidXDR, assertValidXDR, MAX_XDR_STRING_LENGTH } from './utils/xdrValidator';
 
+
+// Profiling
+export { ProfilingService, profilingService } from './profiling';
+export type { ProfileOptions, ProfiledCallMetric, ProfilingConfig, ProfilingLevel, ProfilingReport } from './profiling';
+
 // Testing & MSW
 // export * from './test/msw/setup';
 // export * from './test/msw/handlers';

--- a/src/profiling/index.ts
+++ b/src/profiling/index.ts
@@ -1,0 +1,11 @@
+export {
+  ProfilingService,
+  profilingService,
+} from './profilingService';
+export type {
+  ProfileOptions,
+  ProfiledCallMetric,
+  ProfilingConfig,
+  ProfilingLevel,
+  ProfilingReport,
+} from './profilingService';

--- a/src/profiling/profilingService.ts
+++ b/src/profiling/profilingService.ts
@@ -1,0 +1,200 @@
+export type ProfilingLevel = 'off' | 'basic' | 'detailed';
+
+export interface ProfilingConfig {
+  enabled?: boolean;
+  level?: ProfilingLevel;
+  now?: () => number;
+}
+
+export interface ProfiledCallMetric {
+  id: string;
+  name: string;
+  type: 'contract' | 'rpc' | 'custom';
+  startedAt: string;
+  endedAt: string;
+  durationMs: number;
+  success: boolean;
+  metadata?: Record<string, unknown>;
+  errorMessage?: string;
+  memoryDeltaBytes?: number;
+}
+
+export interface ProfilingReport {
+  generatedAt: string;
+  enabled: boolean;
+  level: ProfilingLevel;
+  totalCalls: number;
+  successfulCalls: number;
+  failedCalls: number;
+  averageDurationMs: number;
+  p95DurationMs: number;
+  slowestCall?: ProfiledCallMetric;
+  byType: Record<string, {
+    count: number;
+    averageDurationMs: number;
+    maxDurationMs: number;
+  }>;
+  calls: ProfiledCallMetric[];
+}
+
+export interface ProfileOptions {
+  type?: ProfiledCallMetric['type'];
+  metadata?: Record<string, unknown>;
+}
+
+const defaultNow = (): number => {
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    return performance.now();
+  }
+  return Date.now();
+};
+
+const getMemoryUsage = (): number | undefined => {
+  if (typeof process !== 'undefined' && typeof process.memoryUsage === 'function') {
+    return process.memoryUsage().heapUsed;
+  }
+  return undefined;
+};
+
+export class ProfilingService {
+  private enabled: boolean;
+  private level: ProfilingLevel;
+  private readonly now: () => number;
+  private metrics: ProfiledCallMetric[] = [];
+  private nextId = 1;
+
+  constructor(config: ProfilingConfig = {}) {
+    this.enabled = config.enabled ?? false;
+    this.level = config.level ?? (this.enabled ? 'basic' : 'off');
+    this.now = config.now ?? defaultNow;
+  }
+
+  enable(level: Exclude<ProfilingLevel, 'off'> = 'basic'): void {
+    this.enabled = true;
+    this.level = level;
+  }
+
+  disable(): void {
+    this.enabled = false;
+    this.level = 'off';
+  }
+
+  isEnabled(): boolean {
+    return this.enabled && this.level !== 'off';
+  }
+
+  clear(): void {
+    this.metrics = [];
+  }
+
+  getMetrics(): ProfiledCallMetric[] {
+    return [...this.metrics];
+  }
+
+  async profile<T>(name: string, operation: () => Promise<T>, options: ProfileOptions = {}): Promise<T> {
+    if (!this.isEnabled()) {
+      return operation();
+    }
+
+    const startedAtWall = new Date();
+    const start = this.now();
+    const memoryStart = this.level === 'detailed' ? getMemoryUsage() : undefined;
+
+    try {
+      const result = await operation();
+      this.record(name, options, startedAtWall, start, true, undefined, memoryStart);
+      return result;
+    } catch (error) {
+      this.record(
+        name,
+        options,
+        startedAtWall,
+        start,
+        false,
+        error instanceof Error ? error.message : String(error),
+        memoryStart
+      );
+      throw error;
+    }
+  }
+
+  profileContractCall<T>(contract: string, method: string, operation: () => Promise<T>, metadata: Record<string, unknown> = {}): Promise<T> {
+    return this.profile(`${contract}.${method}`, operation, {
+      type: 'contract',
+      metadata: { contract, method, ...metadata },
+    });
+  }
+
+  profileRpcCall<T>(method: string, operation: () => Promise<T>, metadata: Record<string, unknown> = {}): Promise<T> {
+    return this.profile(method, operation, {
+      type: 'rpc',
+      metadata: { method, ...metadata },
+    });
+  }
+
+  generateReport(): ProfilingReport {
+    const calls = this.getMetrics();
+    const durations = calls.map((call) => call.durationMs).sort((a, b) => a - b);
+    const totalDuration = durations.reduce((sum, duration) => sum + duration, 0);
+    const p95Index = durations.length === 0 ? -1 : Math.ceil(durations.length * 0.95) - 1;
+    const byType: ProfilingReport['byType'] = {};
+
+    for (const call of calls) {
+      const bucket = byType[call.type] ?? { count: 0, averageDurationMs: 0, maxDurationMs: 0 };
+      bucket.count += 1;
+      bucket.averageDurationMs += call.durationMs;
+      bucket.maxDurationMs = Math.max(bucket.maxDurationMs, call.durationMs);
+      byType[call.type] = bucket;
+    }
+
+    for (const bucket of Object.values(byType)) {
+      bucket.averageDurationMs = bucket.count === 0 ? 0 : bucket.averageDurationMs / bucket.count;
+    }
+
+    return {
+      generatedAt: new Date().toISOString(),
+      enabled: this.isEnabled(),
+      level: this.level,
+      totalCalls: calls.length,
+      successfulCalls: calls.filter((call) => call.success).length,
+      failedCalls: calls.filter((call) => !call.success).length,
+      averageDurationMs: calls.length === 0 ? 0 : totalDuration / calls.length,
+      p95DurationMs: p95Index < 0 ? 0 : durations[p95Index],
+      slowestCall: calls.reduce<ProfiledCallMetric | undefined>(
+        (slowest, call) => !slowest || call.durationMs > slowest.durationMs ? call : slowest,
+        undefined
+      ),
+      byType,
+      calls,
+    };
+  }
+
+  private record(
+    name: string,
+    options: ProfileOptions,
+    startedAtWall: Date,
+    start: number,
+    success: boolean,
+    errorMessage?: string,
+    memoryStart?: number
+  ): void {
+    const endedAtWall = new Date();
+    const memoryEnd = this.level === 'detailed' ? getMemoryUsage() : undefined;
+    const memoryDeltaBytes = memoryStart !== undefined && memoryEnd !== undefined ? memoryEnd - memoryStart : undefined;
+
+    this.metrics.push({
+      id: `profile-${this.nextId++}`,
+      name,
+      type: options.type ?? 'custom',
+      startedAt: startedAtWall.toISOString(),
+      endedAt: endedAtWall.toISOString(),
+      durationMs: Math.max(0, this.now() - start),
+      success,
+      metadata: options.metadata,
+      errorMessage,
+      memoryDeltaBytes,
+    });
+  }
+}
+
+export const profilingService = new ProfilingService();

--- a/tests/profiling/profilingService.test.ts
+++ b/tests/profiling/profilingService.test.ts
@@ -1,0 +1,82 @@
+import { ProfilingService } from '../../src/profiling';
+
+describe('ProfilingService', () => {
+  it('does not record metrics when disabled', async () => {
+    const profiler = new ProfilingService({ enabled: false });
+
+    const result = await profiler.profileContractCall('Vault', 'balanceOf', async () => 42n);
+
+    expect(result).toBe(42n);
+    expect(profiler.getMetrics()).toHaveLength(0);
+    expect(profiler.generateReport().totalCalls).toBe(0);
+  });
+
+  it('records contract call timing and metadata when enabled', async () => {
+    let current = 100;
+    const profiler = new ProfilingService({ enabled: true, now: () => current });
+
+    const result = await profiler.profileContractCall('Vault', 'deposit', async () => {
+      current = 135;
+      return 'tx-hash';
+    }, { contractAddress: '0xabc' });
+
+    expect(result).toBe('tx-hash');
+    const [metric] = profiler.getMetrics();
+    expect(metric).toMatchObject({
+      name: 'Vault.deposit',
+      type: 'contract',
+      durationMs: 35,
+      success: true,
+      metadata: { contract: 'Vault', method: 'deposit', contractAddress: '0xabc' },
+    });
+  });
+
+  it('records RPC latency metrics and generates aggregate reports', async () => {
+    let current = 0;
+    const profiler = new ProfilingService({ enabled: true, now: () => current });
+
+    await profiler.profileRpcCall('getHealth', async () => {
+      current = 10;
+      return { status: 'healthy' };
+    });
+    await profiler.profileRpcCall('simulateTransaction', async () => {
+      current = 40;
+      return { result: 'ok' };
+    });
+
+    const report = profiler.generateReport();
+    expect(report.totalCalls).toBe(2);
+    expect(report.successfulCalls).toBe(2);
+    expect(report.failedCalls).toBe(0);
+    expect(report.averageDurationMs).toBe(20);
+    expect(report.p95DurationMs).toBe(30);
+    expect(report.byType.rpc).toMatchObject({ count: 2, averageDurationMs: 20, maxDurationMs: 30 });
+  });
+
+  it('records failed calls and rethrows the original error', async () => {
+    const profiler = new ProfilingService({ enabled: true });
+
+    await expect(profiler.profileRpcCall('sendTransaction', async () => {
+      throw new Error('RPC unavailable');
+    })).rejects.toThrow('RPC unavailable');
+
+    const report = profiler.generateReport();
+    expect(report.failedCalls).toBe(1);
+    expect(report.calls[0]).toMatchObject({ success: false, errorMessage: 'RPC unavailable' });
+  });
+
+  it('can be enabled, disabled, and cleared', async () => {
+    const profiler = new ProfilingService();
+
+    profiler.enable('detailed');
+    await profiler.profile('customStep', async () => 'ok');
+    expect(profiler.generateReport()).toMatchObject({ enabled: true, level: 'detailed', totalCalls: 1 });
+
+    profiler.disable();
+    await profiler.profile('ignoredStep', async () => 'ok');
+    expect(profiler.getMetrics()).toHaveLength(1);
+
+    profiler.clear();
+    expect(profiler.getMetrics()).toHaveLength(0);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "CommonJS",
     "moduleResolution": "Node",
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",


### PR DESCRIPTION
Motivation
Provide an opt-in profiling facility to measure SDK contract call performance, RPC latency, execution durations, and optional memory deltas to help diagnose bottlenecks and optimize integrations.
Keep profiling low-overhead and configurable so developers can enable basic or detailed sampling only when needed.
Description
Add a new ProfilingService implementation with enable/disable, levels off|basic|detailed, wrappers profileContractCall/profileRpcCall/profile, metric collection, and a generateReport API in src/profiling/profilingService.ts.
Export profiling utilities and types via src/profiling/index.ts and re-export them from the SDK entry in src/index.ts.
Add unit tests for disabled behavior, contract timing, RPC latency aggregation, failure capture, and lifecycle operations in tests/profiling/profilingService.test.ts.
Adjust tsconfig.json ignoreDeprecations to a TypeScript-supported value to allow running the focused profiling tests.
Testing
Ran the focused profiling test: npm test -- --runTestsByPath tests/profiling/profilingService.test.ts --coverage=false and it passed (5 tests).
Verified TypeScript compilation for the new file with npx tsc --noEmit --pretty false src/profiling/profilingService.ts and it passed.
Reported that the full test suite npm test -- --coverage=false still fails due to pre-existing, unrelated syntax/module issues in other files (e.g., src/client/stellarClient.ts, src/utils/transactionBuilder.ts, packages/core/...) which are outside this change and therefore not addressed here.
Closes https://github.com/Axionvera/axionvera-sdk/issues/225