### PR TITLE
Sdk dependency injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Migration Guide](#-migration-guide)
 - [Usage Examples](#-usage-examples)
 - [Module Architecture](#-module-architecture)
+- [Dependency Injection](#dependency-injection)
 - [API Reference](#-api-reference)
 - [Troubleshooting](#-troubleshooting)
 - [Contributing](#-contributing)
@@ -61,16 +62,19 @@ The SDK requires Node.js 18+ and has `@stellar/stellar-sdk` as a peer dependency
 Install the package using your preferred package manager:
 
 **Using npm:**
+
 ```bash
 npm install axionvera-sdk @stellar/stellar-sdk
 ```
 
 **Using yarn:**
+
 ```bash
 yarn add axionvera-sdk @stellar/stellar-sdk
 ```
 
 **Using pnpm:**
+
 ```bash
 pnpm add axionvera-sdk @stellar/stellar-sdk
 ```
@@ -97,15 +101,11 @@ Ensure your `tsconfig.json` has `strict: true` for full type safety:
 Here is a step-by-step guide to initializing the SDK, connecting a local wallet, and executing a transaction on the Vault contract.
 
 ```typescript
-import { Keypair } from "@stellar/stellar-sdk";
-import {
-  LocalKeypairWalletConnector,
-  StellarClient,
-  VaultContract
-} from "axionvera-sdk";
+import { Keypair } from '@stellar/stellar-sdk';
+import { LocalKeypairWalletConnector, StellarClient, VaultContract } from 'axionvera-sdk';
 
 // 1. Initialize the Stellar Client for the Testnet
-const client = new StellarClient({ network: "testnet" });
+const client = new StellarClient({ network: 'testnet' });
 
 // 2. Set up the Wallet Connector with your secret key
 const keypair = Keypair.fromSecret(process.env.STELLAR_SECRET_KEY!);
@@ -115,21 +115,21 @@ const wallet = new LocalKeypairWalletConnector(keypair);
 const vault = new VaultContract({
   client,
   contractId: process.env.AXIONVERA_VAULT_CONTRACT_ID!,
-  wallet
+  wallet,
 });
 
 // 4. Execute a transaction
 async function run() {
   try {
-    console.log("Depositing 1000 units into the vault...");
-    
+    console.log('Depositing 1000 units into the vault...');
+
     // The SDK automatically handles building, simulating, signing, and submitting the transaction
     const depositResult = await vault.deposit({ amount: 1000n });
-    
-    console.log("Transaction successful!");
-    console.log("Result:", depositResult);
+
+    console.log('Transaction successful!');
+    console.log('Result:', depositResult);
   } catch (error) {
-    console.error("Transaction failed:", error);
+    console.error('Transaction failed:', error);
   }
 }
 
@@ -145,11 +145,13 @@ Try the SDK in your browser without any local setup using our interactive playgr
 [![Open in StackBlitz](https://stackblitz.com/github/Listoncrypt/axionvera-sdk/badge.svg)](https://stackblitz.com/github/Listoncrypt/axionvera-sdk?file=examples/browser-sandbox/index.ts)
 
 The browser sandbox uses the `MockWalletConnector` to demonstrate SDK initialization and wallet connection flows without requiring a real wallet extension. This is perfect for:
+
 - Quick prototyping and testing
 - Understanding the SDK API
 - Demonstrating the SDK to stakeholders
 
 To run the sandbox locally:
+
 ```bash
 cd examples/browser-sandbox
 npm install
@@ -160,7 +162,7 @@ npm run dev
 
 ## � Migration Guide
 
-**Coming from Stellar Classic (stellar-sdk v10)?** 
+**Coming from Stellar Classic (stellar-sdk v10)?**
 
 We've prepared a comprehensive [Migration Guide](./docs/MIGRATION_GUIDE.md) to help you transition from Classic operations to Soroban smart contracts. The guide covers:
 
@@ -187,11 +189,8 @@ We provide detailed, runnable examples in the [`examples/`](./examples/) directo
 When a signed transaction is still pending and the network fee market moves, you can wrap the original signed XDR in a fee bump envelope instead of asking the user to re-sign the contract call.
 
 ```typescript
-import { Keypair, Networks } from "@stellar/stellar-sdk";
-import {
-  LocalKeypairWalletConnector,
-  bumpTransactionFee
-} from "axionvera-sdk";
+import { Keypair, Networks } from '@stellar/stellar-sdk';
+import { LocalKeypairWalletConnector, bumpTransactionFee } from 'axionvera-sdk';
 
 const sponsorWallet = new LocalKeypairWalletConnector(
   Keypair.fromSecret(process.env.SPONSOR_SECRET_KEY!)
@@ -199,13 +198,10 @@ const sponsorWallet = new LocalKeypairWalletConnector(
 
 const feeBumpEnvelopeXdr = bumpTransactionFee(userSignedXdr, 500, {
   feeSource: await sponsorWallet.getPublicKey(),
-  networkPassphrase: Networks.TESTNET
+  networkPassphrase: Networks.TESTNET,
 });
 
-const sponsorSignedXdr = await sponsorWallet.signTransaction(
-  feeBumpEnvelopeXdr,
-  Networks.TESTNET
-);
+const sponsorSignedXdr = await sponsorWallet.signTransaction(feeBumpEnvelopeXdr, Networks.TESTNET);
 
 await client.sendTransaction(sponsorSignedXdr);
 ```
@@ -219,17 +215,21 @@ This preserves the original user signature on the inner transaction. Only the ou
 The SDK is organized into clear layers to keep concerns separated:
 
 ### `src/client/`
+
 - **`StellarClient`**: Main entry point for Soroban RPC connections
 - **`FaucetClient`**: Automated account funding for test networks
 
 ### `src/contracts/`
+
 - **`VaultContract`**: High-level wrapper for the Axionvera Vault contract
 
 ### `src/wallet/`
+
 - **`WalletConnector`**: Interface for wallet signing
 - **`LocalKeypairWalletConnector`**: Built-in keypair signer for server-side use
 
 ### `src/utils/`
+
 - **`networkConfig`**: Default RPC URLs and network passphrases
 - **`transactionBuilder`**: Helpers to build Soroban contract calls
 - **`concurrencyQueue`**: Rate limiting for high-volume apps
@@ -238,16 +238,47 @@ The SDK is organized into clear layers to keep concerns separated:
 - **`logger`**: Built-in logging with sensitive data redaction
 
 ### `src/errors/`
+
 - Typed error classes for different failure modes
 
 ---
+
+## Dependency Injection
+
+Axionvera SDK services can be resolved through a lightweight dependency container. This keeps core modules loosely coupled while preserving the existing `new StellarClient(...)` API.
+
+```typescript
+import { StellarClient, createServiceContainer } from 'axionvera-sdk';
+
+const container = createServiceContainer({
+  rpcClient: mockRpcClient,
+  httpClient: mockHttpClient,
+  logger: testLogger,
+});
+
+const client = new StellarClient({
+  network: 'testnet',
+  container,
+});
+```
+
+The default dependency graph is:
+
+- `StellarClient` resolves a `LoggerService`, `HttpClient`, `RpcServer`, and optional `WebSocketManagerService`.
+- `defaultRpcClientFactory` creates `@stellar/stellar-sdk` RPC clients and wraps them with concurrency control when `concurrencyConfig` is provided.
+- `defaultHttpClientFactory` creates the retry-enabled Axios client.
+- `defaultWebSocketManagerFactory` wires WebSocket callbacks to the resolved logger.
+
+Migration is incremental: existing callers do not need changes, while tests and advanced integrations can override individual services with `services` or provide a preconfigured `ServiceContainer`.
 
 ## 📚 API Reference
 
 For deep architectural details, see the [SDK Overview](./docs/sdk-overview.md) and [Usage Guide](./docs/usage-guide.md). Below is a summary of the core API classes:
 
 ### `StellarClient`
+
 The core client wrapping the Soroban RPC connection.
+
 - `getHealth()`: Check the health of the RPC node.
 - `simulateTransaction(tx)`: Simulates a transaction to calculate fees and resource footprints.
 - `prepareTransaction(tx)`: Attaches the simulation footprints and minimum fees to the transaction.
@@ -256,7 +287,9 @@ The core client wrapping the Soroban RPC connection.
 - `logLevel`: Property in `StellarClientOptions` to control SDK output visibility.
 
 ### `VaultContract`
+
 A high-level abstraction for the Axionvera Vault smart contract.
+
 - `deposit({ amount, from })`: Deposits tokens into the vault.
 - `withdraw({ amount, from })`: Withdraws tokens from the vault.
 - `getBalance({ account })`: Retrieves the vault balance for a specific account.
@@ -265,17 +298,23 @@ A high-level abstraction for the Axionvera Vault smart contract.
 - `claimRewards({ from })`: Claims pending rewards for the caller.
 
 ### `FaucetClient`
+
 Automated funding for Testnet and Futurenet.
+
 - `fundAccount(publicKey)`: Hits the correct Friendbot endpoint based on the client's network. Throws `FaucetRateLimitError` if throttled.
 
 ### `SEP-0007 Utilities`
+
 Standardized URI generation for mobile wallet integration.
+
 - `generateTransactionURI(xdr, callbackUrl)`: Generates a `web+stellar:tx` URI.
 - `generatePayURI(destination, amount, assetCode, assetIssuer)`: Generates a `web+stellar:pay` URI.
 - `bumpTransactionFee(signedXdr, newBaseFee, options)`: Wraps a signed transaction XDR in an unsigned fee bump envelope for sponsor signing.
 
 ### `WalletConnector` (Interface)
+
 Implement this interface to integrate browser extension wallets (like Freighter) or use the provided `LocalKeypairWalletConnector` for backend/scripting services.
+
 - `getPublicKey()`: Returns the public key of the connected wallet.
 - `signTransaction(xdr, passphrase)`: Signs a prepared transaction XDR string and returns the signed XDR.
 
@@ -301,6 +340,7 @@ We welcome and appreciate contributions from the community! Whether it's reporti
 Please read our [Contributing Guidelines](./CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.
 
 ### Development Setup
+
 To set up the project locally for development:
 
 ```bash
@@ -335,4 +375,5 @@ If you have any questions, feedback, or need support, feel free to reach out:
 - **Twitter**: [@Axionvera](https://twitter.com/axionvera)
 
 ---
-*Built with ❤️ by the Axionvera Team.*
+
+_Built with ❤️ by the Axionvera Team._

--- a/src/client/stellarClient.ts
+++ b/src/client/stellarClient.ts
@@ -13,8 +13,8 @@ import {
 } from "@stellar/stellar-sdk";
 
 import { AxionveraNetwork, resolveNetworkConfig } from "../utils/networkConfig";
-import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG, createConcurrencyControlledClient } from "../utils/concurrencyQueue";
-import { RetryConfig, createHttpClientWithRetry, retry } from "../utils/httpInterceptor";
+import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG } from "../utils/concurrencyQueue";
+import { RetryConfig, retry } from "../utils/httpInterceptor";
 import { normalizeRpcError, normalizeTransactionError, TimeoutError, InsecureNetworkError, AxionveraError, AxionveraRPCError, SimulationFailedError } from "../errors/axionveraError";
 import {
   validateRpcResponse,
@@ -31,6 +31,8 @@ import { WebSocketManager } from "./websocket/websocketManager";
 import { WebSocketConfig } from "./websocket/types";
 import { Logger } from "../utils/logger";
 import { WalletConnector } from "../wallet/walletConnector";
+import { ServiceContainer, createServiceContainer } from "../core/serviceContainer";
+import { ServiceOverrides } from "../core/serviceInterfaces";
 
 const DEFAULT_FEE_BUFFER_MULTIPLIER = 1.15;
 
@@ -64,6 +66,10 @@ export type StellarClientOptions = {
   /** Hard ceiling for the total prepared fee in stroops. */
   maxFeeLimit?: number;
   allowHttp?: boolean;
+  /** Core service overrides for dependency injection. */
+  services?: ServiceOverrides;
+  /** Dependency container used to resolve SDK services at runtime. */
+  container?: ServiceContainer;
   /** Timeout in milliseconds for account fetching (default: 2000) */
   accountFetchTimeoutMs?: number;
   /** TTL in milliseconds for cached account sequence (default: 5000) */
@@ -320,8 +326,13 @@ export class StellarClient {
     };
     this.concurrencyEnabled = !!options?.concurrencyConfig;
     this.retryConfig = options?.retryConfig ?? {};
-    this.httpClient = createHttpClientWithRetry(this.retryConfig);
-    this.logger = options?.logger ?? new Logger();
+    const serviceOverrides = {
+      ...options?.services,
+      rpcClient: options?.rpcClient ?? options?.services?.rpcClient,
+    };
+    const container = options?.container ?? createServiceContainer(serviceOverrides);
+    this.httpClient = container.getHttpClient({ retryConfig: this.retryConfig });
+    this.logger = options?.logger ?? container.getLogger();
 this.accountFetchTimeoutMs = options?.accountFetchTimeoutMs ?? 2000;
     this.cacheTtlMs = options?.cacheTtlMs ?? 5000;
     this.accountSequenceCache = new Map();
@@ -342,30 +353,19 @@ this.accountCache = new Map();
 
     // Initialize WebSocket manager if configuration is provided
     if (options?.webSocketConfig) {
-      this.webSocketManager = new WebSocketManager(
-        this.rpcUrl,
-        options.webSocketConfig,
-        {
-          onEvent: (event) => this.logger.debug('WebSocket event received:', event),
-          onConnectionChange: (connected) => this.logger.debug(`WebSocket connection changed: ${connected}`),
-          logger: this.logger,
-        }
-      );
+      this.webSocketManager = container.getWebSocketManager({
+        rpcUrl: this.rpcUrl,
+        config: options.webSocketConfig,
+        logger: this.logger,
+      });
     }
 
-    if (options?.rpcClient) {
-      this.rpc = options.rpcClient;
-    } else {
-      const allowHttp = this.rpcUrl.startsWith("http://");
-      const baseRpc = new rpc.Server(this.rpcUrl, { allowHttp });
-
-      // Apply concurrency control if enabled
-      if (this.concurrencyEnabled) {
-        this.rpc = createConcurrencyControlledClient(baseRpc, this.concurrencyConfig);
-      } else {
-        this.rpc = baseRpc;
-      }
-    }
+    this.rpc = container.getRpcClient({
+      rpcUrl: this.rpcUrl,
+      allowHttp: this.rpcUrl.startsWith("http://"),
+      concurrencyEnabled: this.concurrencyEnabled,
+      concurrencyConfig: this.concurrencyConfig,
+    });
   }
 
   /**

--- a/src/core/serviceContainer.ts
+++ b/src/core/serviceContainer.ts
@@ -1,0 +1,82 @@
+import { rpc } from '@stellar/stellar-sdk';
+
+import { createConcurrencyControlledClient } from '../utils/concurrencyQueue';
+import { createHttpClientWithRetry } from '../utils/httpInterceptor';
+import { Logger } from '../utils/logger';
+import { WebSocketManager } from '../client/websocket/websocketManager';
+import type {
+  CoreServices,
+  HttpClient,
+  HttpClientFactoryOptions,
+  LoggerService,
+  RpcClientFactoryOptions,
+  RpcServer,
+  ServiceOverrides,
+  WebSocketManagerFactoryOptions,
+  WebSocketManagerService,
+} from './serviceInterfaces';
+
+export const defaultRpcClientFactory = (options: RpcClientFactoryOptions): RpcServer => {
+  const baseRpc = new rpc.Server(options.rpcUrl, { allowHttp: options.allowHttp });
+
+  if (!options.concurrencyEnabled) {
+    return baseRpc;
+  }
+
+  return createConcurrencyControlledClient(baseRpc, options.concurrencyConfig);
+};
+
+export const defaultHttpClientFactory = (options: HttpClientFactoryOptions): HttpClient => {
+  return createHttpClientWithRetry(options.retryConfig);
+};
+
+export const defaultLoggerFactory = (): LoggerService => new Logger();
+
+export const defaultWebSocketManagerFactory = (
+  options: WebSocketManagerFactoryOptions
+): WebSocketManagerService => {
+  return new WebSocketManager(options.rpcUrl, options.config, {
+    onEvent: (event) => options.logger.debug('WebSocket event received:', event),
+    onConnectionChange: (connected) =>
+      options.logger.debug(`WebSocket connection changed: ${connected}`),
+    logger: options.logger,
+  });
+};
+
+export class ServiceContainer {
+  private readonly services: CoreServices;
+
+  constructor(overrides: ServiceOverrides = {}) {
+    this.services = {
+      rpcClientFactory: defaultRpcClientFactory,
+      httpClientFactory: defaultHttpClientFactory,
+      loggerFactory: defaultLoggerFactory,
+      webSocketManagerFactory: defaultWebSocketManagerFactory,
+      ...overrides,
+    };
+  }
+
+  getLogger(): LoggerService {
+    return this.services.logger ?? this.services.loggerFactory();
+  }
+
+  getHttpClient(options: HttpClientFactoryOptions): HttpClient {
+    return this.services.httpClient ?? this.services.httpClientFactory(options);
+  }
+
+  getRpcClient(options: RpcClientFactoryOptions): RpcServer {
+    return this.services.rpcClient ?? this.services.rpcClientFactory(options);
+  }
+
+  getWebSocketManager(options: WebSocketManagerFactoryOptions): WebSocketManagerService {
+    return this.services.webSocketManager ?? this.services.webSocketManagerFactory(options);
+  }
+
+  extend(overrides: ServiceOverrides): ServiceContainer {
+    return new ServiceContainer({ ...this.services, ...overrides });
+  }
+}
+
+export function createServiceContainer(overrides: ServiceOverrides = {}): ServiceContainer {
+  return new ServiceContainer(overrides);
+}

--- a/src/core/serviceInterfaces.ts
+++ b/src/core/serviceInterfaces.ts
@@ -1,0 +1,49 @@
+import type { AxiosInstance } from 'axios';
+import type { rpc } from '@stellar/stellar-sdk';
+import type { RetryConfig } from '../utils/httpInterceptor';
+import type { ConcurrencyConfig } from '../utils/concurrencyQueue';
+import type { Logger } from '../utils/logger';
+import type { WebSocketConfig } from '../client/websocket/types';
+import type { WebSocketManager } from '../client/websocket/websocketManager';
+
+export type RpcServer = rpc.Server;
+export type HttpClient = AxiosInstance;
+export type LoggerService = Logger;
+export type WebSocketManagerService = WebSocketManager;
+
+export interface RpcClientFactoryOptions {
+  rpcUrl: string;
+  allowHttp: boolean;
+  concurrencyEnabled: boolean;
+  concurrencyConfig: ConcurrencyConfig;
+}
+
+export interface HttpClientFactoryOptions {
+  retryConfig?: Partial<RetryConfig>;
+}
+
+export interface WebSocketManagerFactoryOptions {
+  rpcUrl: string;
+  config: WebSocketConfig;
+  logger: LoggerService;
+}
+
+export type RpcClientFactory = (options: RpcClientFactoryOptions) => RpcServer;
+export type HttpClientFactory = (options: HttpClientFactoryOptions) => HttpClient;
+export type LoggerFactory = () => LoggerService;
+export type WebSocketManagerFactory = (
+  options: WebSocketManagerFactoryOptions
+) => WebSocketManagerService;
+
+export interface CoreServices {
+  rpcClient?: RpcServer;
+  rpcClientFactory: RpcClientFactory;
+  httpClient?: HttpClient;
+  httpClientFactory: HttpClientFactory;
+  logger?: LoggerService;
+  loggerFactory: LoggerFactory;
+  webSocketManager?: WebSocketManagerService;
+  webSocketManagerFactory: WebSocketManagerFactory;
+}
+
+export type ServiceOverrides = Partial<CoreServices>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,49 +1,79 @@
 // Errors
 export {
-    AxionveraError,
-    NetworkError,
-    AuthenticationError,
-    RateLimitError,
-    ValidationError,
-    TransactionError,
-    RpcError,
-    ContractError,
-    TimeoutError,
-    TransactionTimeoutError,
-    InsufficientFundsError,
-    InvalidSignatureError,
-    InvalidXDRError,
-    SimulationError,
-    WalletNotInstalledError,
-    FaucetRateLimitError,
-    InsecureNetworkError,
-    NetworkMismatchError,
-    AxionveraRPCError,
-    SimulationFailedError,
-    SlippageToleranceExceededError,
-    WalletConnectionError,
-    toAxionveraError,
-    normalizeRpcError,
-    normalizeTransactionError,
-    normalizeContractError,
-    normalizeSimulationError
+  AxionveraError,
+  NetworkError,
+  AuthenticationError,
+  RateLimitError,
+  ValidationError,
+  TransactionError,
+  RpcError,
+  ContractError,
+  TimeoutError,
+  TransactionTimeoutError,
+  InsufficientFundsError,
+  InvalidSignatureError,
+  InvalidXDRError,
+  SimulationError,
+  WalletNotInstalledError,
+  FaucetRateLimitError,
+  InsecureNetworkError,
+  NetworkMismatchError,
+  AxionveraRPCError,
+  SimulationFailedError,
+  SlippageToleranceExceededError,
+  WalletConnectionError,
+  toAxionveraError,
+  normalizeRpcError,
+  normalizeTransactionError,
+  normalizeContractError,
+  normalizeSimulationError,
 } from './errors/axionveraError';
+
+// Dependency Injection
+export {
+  ServiceContainer,
+  createServiceContainer,
+  defaultRpcClientFactory,
+  defaultHttpClientFactory,
+  defaultLoggerFactory,
+  defaultWebSocketManagerFactory,
+} from './core/serviceContainer';
+export type {
+  CoreServices,
+  ServiceOverrides,
+  RpcClientFactory,
+  HttpClientFactory,
+  LoggerFactory,
+  WebSocketManagerFactory,
+  RpcClientFactoryOptions,
+  HttpClientFactoryOptions,
+  WebSocketManagerFactoryOptions,
+  RpcServer,
+  HttpClient,
+  LoggerService,
+  WebSocketManagerService,
+} from './core/serviceInterfaces';
 
 // Client
 export { StellarClient, HYDRATION_STATE_VERSION } from './client/stellarClient';
 export { FaucetClient } from './client/faucetClient';
-export type { StellarClientOptions, GetContractEventsOptions, GetContractEventsResult, ContractEventResult } from './client/stellarClient';
+export type {
+  StellarClientOptions,
+  GetContractEventsOptions,
+  GetContractEventsResult,
+  ContractEventResult,
+} from './client/stellarClient';
 export type { StellarClientOptions } from './client/stellarClient';
 export type { LogLevel, CustomLogger } from './utils/logger';
 export type {
-    StellarClientOptions,
-    PendingTransaction,
-    TrackedTransaction,
-    SerializedPendingTransaction,
-    ExportedState,
-    TrackTransactionOptions,
-    SimulationContext,
-    SerializableValue,
+  StellarClientOptions,
+  PendingTransaction,
+  TrackedTransaction,
+  SerializedPendingTransaction,
+  ExportedState,
+  TrackTransactionOptions,
+  SimulationContext,
+  SerializableValue,
 } from './client/stellarClient';
 
 // Contracts
@@ -62,11 +92,34 @@ export type { WalletConnector } from './wallet/walletConnector';
 // Utils
 export { ConcurrencyQueue, createConcurrencyControlledClient } from './utils/concurrencyQueue';
 export { retry, createHttpClientWithRetry } from './utils/httpInterceptor';
-export { buildContractCallOperation, buildContractCallTransaction, buildBaseTransaction, toScVal, ContractCallBuilder } from './utils/transactionBuilder';
-export type { BuildBaseTransactionParams, BuildContractCallParams, ContractCallArg } from './utils/transactionBuilder';
-export { buildContractCallOperation, buildContractCallTransaction, buildBaseTransaction, bumpTransactionFee, toScVal } from './utils/transactionBuilder';
-export type { BuildBaseTransactionParams, BumpTransactionFeeOptions } from './utils/transactionBuilder';
-export { getDefaultRpcUrl, getNetworkPassphrase, resolveNetworkConfig } from './utils/networkConfig';
+export {
+  buildContractCallOperation,
+  buildContractCallTransaction,
+  buildBaseTransaction,
+  toScVal,
+  ContractCallBuilder,
+} from './utils/transactionBuilder';
+export type {
+  BuildBaseTransactionParams,
+  BuildContractCallParams,
+  ContractCallArg,
+} from './utils/transactionBuilder';
+export {
+  buildContractCallOperation,
+  buildContractCallTransaction,
+  buildBaseTransaction,
+  bumpTransactionFee,
+  toScVal,
+} from './utils/transactionBuilder';
+export type {
+  BuildBaseTransactionParams,
+  BumpTransactionFeeOptions,
+} from './utils/transactionBuilder';
+export {
+  getDefaultRpcUrl,
+  getNetworkPassphrase,
+  resolveNetworkConfig,
+} from './utils/networkConfig';
 export { generateTransactionURI, generatePayURI } from './utils/sep7';
 export { getRequiredSigners } from './utils/getRequiredSigners';
 export { verifyWebhookSignature } from './utils/webhooks';

--- a/tests/core/serviceContainer.test.ts
+++ b/tests/core/serviceContainer.test.ts
@@ -1,0 +1,71 @@
+import { createServiceContainer, ServiceContainer } from '../../src/core/serviceContainer';
+import { StellarClient } from '../../src/client/stellarClient';
+import { Logger } from '../../src/utils/logger';
+
+describe('ServiceContainer', () => {
+  it('resolves explicitly injected singleton services', () => {
+    const logger = new Logger('none');
+    const httpClient = { get: jest.fn() } as any;
+    const rpcClient = { getHealth: jest.fn() } as any;
+    const webSocketManager = { connect: jest.fn() } as any;
+
+    const container = createServiceContainer({
+      logger,
+      httpClient,
+      rpcClient,
+      webSocketManager,
+    });
+
+    expect(container.getLogger()).toBe(logger);
+    expect(container.getHttpClient({})).toBe(httpClient);
+    expect(
+      container.getRpcClient({
+        rpcUrl: 'https://example.com',
+        allowHttp: false,
+        concurrencyEnabled: false,
+        concurrencyConfig: {} as any,
+      })
+    ).toBe(rpcClient);
+    expect(
+      container.getWebSocketManager({
+        rpcUrl: 'https://example.com',
+        config: {},
+        logger,
+      })
+    ).toBe(webSocketManager);
+  });
+
+  it('allows StellarClient dependencies to be injected at runtime', async () => {
+    const rpcClient = {
+      getHealth: jest.fn().mockResolvedValue({ status: 'healthy', version: 'test' }),
+    } as any;
+    const httpClient = { get: jest.fn() } as any;
+    const logger = new Logger('none');
+
+    const client = new StellarClient({
+      network: 'testnet',
+      services: {
+        rpcClient,
+        httpClient,
+        logger,
+      },
+    });
+
+    await expect(client.getHealth()).resolves.toEqual({ status: 'healthy', version: 'test' });
+    expect(client.rpc).toBe(rpcClient);
+    expect(client.httpClient).toBe(httpClient);
+    expect(client.logger).toBe(logger);
+  });
+
+  it('can extend a container without mutating the original registration graph', () => {
+    const logger = new Logger('none');
+    const base = new ServiceContainer({ logger });
+    const httpClient = { get: jest.fn() } as any;
+    const extended = base.extend({ httpClient });
+
+    expect(base.getLogger()).toBe(logger);
+    expect(extended.getLogger()).toBe(logger);
+    expect(extended.getHttpClient({})).toBe(httpClient);
+    expect(base.getHttpClient({})).not.toBe(httpClient);
+  });
+});


### PR DESCRIPTION
Motivation
Introduce dependency injection so core SDK services can be swapped for testing or alternative implementations and reduce tight coupling between modules.
Provide a minimal, opt-in container that preserves the existing new StellarClient(...) API while enabling incremental adoption in tests and integrations.
Description
Added service contracts in src/core/serviceInterfaces.ts and a lightweight container with default factories in src/core/serviceContainer.ts including defaultRpcClientFactory, defaultHttpClientFactory, defaultLoggerFactory, and defaultWebSocketManagerFactory.
Wired StellarClient to resolve services from a container by adding services?: ServiceOverrides and container?: ServiceContainer to StellarClientOptions and using createServiceContainer when a container is not provided while preserving existing rpcClient/logger behavior via rpcClient passthrough.
Exported the DI types and helpers from the public API in src/index.ts and documented usage and the default dependency graph in README.md.
Added unit tests tests/core/serviceContainer.test.ts covering explicit singleton overrides, runtime injection into StellarClient, and container extension semantics.
Testing
Ran npm test -- --runTestsByPath tests/core/serviceContainer.test.ts, which failed before test execution due to pre-existing TypeScript configuration/source issues (invalid --ignoreDeprecations and unrelated parse/type errors in existing files).
Ran npx tsc --noEmit ... scoped to the new container files, which surfaced unrelated TypeScript errors in other modules when the project-wide typechecker attempted to resolve imports.
Ran formatting (prettier) and linting over the new files which completed for valid files but encountered existing syntax/type issues in other project sources; the new container code and tests are formatted and included in the commit.
Closes https://github.com/Axionvera/axionvera-sdk/issues/231