### PR TITLE
feat: add dynamic contract adapter framework

### DIFF
--- a/src/adapters/adapterRegistry.ts
+++ b/src/adapters/adapterRegistry.ts
@@ -1,0 +1,61 @@
+﻿import { ContractAdapter, AdapterRegistryConfig } from './types';
+
+export class AdapterRegistry {
+  private adapters: Map<string, ContractAdapter> = new Map();
+  private defaultName: string | null = null;
+
+  constructor(config?: AdapterRegistryConfig) {
+    if (config?.defaultAdapter) {
+      this.defaultName = config.defaultAdapter;
+    }
+  }
+
+  register(adapter: ContractAdapter): void {
+    this.adapters.set(adapter.name, adapter);
+    if (!this.defaultName) {
+      this.defaultName = adapter.name;
+    }
+  }
+
+  unregister(name: string): boolean {
+    if (this.defaultName === name) {
+      this.defaultName = null;
+    }
+    return this.adapters.delete(name);
+  }
+
+  get(name?: string): ContractAdapter | undefined {
+    const key = name ?? this.defaultName;
+    if (!key) return undefined;
+    return this.adapters.get(key);
+  }
+
+  async findAdapter(contractId: string): Promise<ContractAdapter | undefined> {
+    for (const adapter of this.adapters.values()) {
+      if (await adapter.supports(contractId)) {
+        return adapter;
+      }
+    }
+    return undefined;
+  }
+
+  setDefault(name: string): void {
+    if (!this.adapters.has(name)) {
+      throw new Error('Adapter not registered: ' + name);
+    }
+    this.defaultName = name;
+  }
+
+  getDefault(): ContractAdapter | undefined {
+    if (!this.defaultName) return undefined;
+    return this.adapters.get(this.defaultName);
+  }
+
+  list(): ContractAdapter[] {
+    return [...this.adapters.values()];
+  }
+
+  count(): number {
+    return this.adapters.size;
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,3 @@
+﻿export * from './types';
+export * from './adapterRegistry';
+export * from './vaultAdapter';

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,0 +1,15 @@
+﻿export interface ContractAdapter {
+  readonly name: string;
+  readonly version: string;
+  /** Check if this adapter supports a given contract address */
+  supports(contractId: string): Promise<boolean>;
+  /** Read a value from the contract */
+  read<T>(contractId: string, method: string, ...args: any[]): Promise<T>;
+  /** Invoke a write method on the contract */
+  write(contractId: string, method: string, ...args: any[]): Promise<string>;
+}
+
+export interface AdapterRegistryConfig {
+  /** Default adapter name to use when none specified */
+  defaultAdapter?: string;
+}

--- a/src/adapters/vaultAdapter.ts
+++ b/src/adapters/vaultAdapter.ts
@@ -1,0 +1,23 @@
+﻿import { ContractAdapter } from './types';
+
+export class VaultAdapter implements ContractAdapter {
+  readonly name = 'vault';
+  readonly version = '0.1.0';
+
+  async supports(contractId: string): Promise<boolean> {
+    return contractId.startsWith('C') && contractId.length === 56;
+  }
+
+  async read<T>(contractId: string, method: string, ...args: any[]): Promise<T> {
+    const key = 'vault:' + contractId + ':' + method + ':' + JSON.stringify(args);
+    const cached = sessionStorage.getItem(key);
+    if (cached) return JSON.parse(cached) as T;
+    const result = { deposit: 0, withdraw: 0 } as T;
+    sessionStorage.setItem(key, JSON.stringify(result));
+    return result;
+  }
+
+  async write(contractId: string, method: string, ...args: any[]): Promise<string> {
+    return 'tx_' + method + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 8);
+  }
+}

--- a/tests/adapters/adapterRegistry.test.ts
+++ b/tests/adapters/adapterRegistry.test.ts
@@ -1,0 +1,76 @@
+﻿import { AdapterRegistry } from '../../src/adapters/adapterRegistry';
+import { ContractAdapter } from '../../src/adapters/types';
+
+function mockAdapter(name: string, supports = true): ContractAdapter {
+  return {
+    name,
+    version: '1.0.0',
+    supports: async () => supports,
+    read: async () => ({ data: name }),
+    write: async () => 'tx_' + name + '_123',
+  };
+}
+
+describe('AdapterRegistry', () => {
+  let registry: AdapterRegistry;
+
+  beforeEach(() => {
+    registry = new AdapterRegistry();
+  });
+
+  it('registers and retrieves an adapter', () => {
+    const adapter = mockAdapter('vault');
+    registry.register(adapter);
+    expect(registry.get('vault')).toBe(adapter);
+  });
+
+  it('returns undefined for unknown adapter', () => {
+    expect(registry.get('nonexistent')).toBeUndefined();
+  });
+
+  it('sets first registered as default', () => {
+    registry.register(mockAdapter('vault'));
+    registry.register(mockAdapter('token'));
+    expect(registry.getDefault()?.name).toBe('vault');
+  });
+
+  it('unregisters adapters', () => {
+    const adapter = mockAdapter('vault');
+    registry.register(adapter);
+    registry.unregister('vault');
+    expect(registry.get('vault')).toBeUndefined();
+  });
+
+  it('finds adapter by contract support', async () => {
+    const vault = mockAdapter('vault', true);
+    const token = mockAdapter('token', false);
+    registry.register(vault);
+    registry.register(token);
+
+    const found = await registry.findAdapter('CABC123');
+    expect(found?.name).toBe('vault');
+  });
+
+  it('lists all registered adapters', () => {
+    registry.register(mockAdapter('a'));
+    registry.register(mockAdapter('b'));
+    expect(registry.list()).toHaveLength(2);
+  });
+
+  it('returns correct count', () => {
+    registry.register(mockAdapter('a'));
+    registry.register(mockAdapter('b'));
+    expect(registry.count()).toBe(2);
+  });
+
+  it('throws when setting default to unregistered adapter', () => {
+    expect(() => registry.setDefault('nonexistent')).toThrow('not registered');
+  });
+
+  it('uses constructor default', () => {
+    const adapter = mockAdapter('custom');
+    const r = new AdapterRegistry({ defaultAdapter: 'custom' });
+    r.register(adapter);
+    expect(r.getDefault()?.name).toBe('custom');
+  });
+});


### PR DESCRIPTION
Closes #237

ContractAdapter interface with AdapterRegistry for runtime adapter selection.

5 files, 178 lines, 9 tests: types, registry, vault adapter example, tests.