### PR TITLE
Feature/response metadata

### DIFF
--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -141,6 +141,88 @@ Workflow:
 
 This keeps the original contract payload intact while letting enterprise apps react to volatile fee markets.
 
+## 8) Access response metadata for diagnostics
+
+When debugging issues or filing support tickets, you can opt into **response metadata**
+that includes request IDs, timing information, and correlation identifiers. This is an
+opt-in feature — the default API remains backwards-compatible and returns plain data.
+
+### Per-call opt-in
+
+Pass `includeMeta: true` to any service method:
+
+```ts
+import { StellarClient } from "axionvera-sdk";
+
+const client = new StellarClient({ network: "testnet" });
+
+// With metadata
+const { data, meta } = await client.getHealth({ includeMeta: true });
+
+console.log("Request ID:",    meta.clientRequestId);
+console.log("Server req ID:", meta.requestId);
+console.log("Duration:",      meta.durationMs, "ms");
+console.log("Status:",        meta.statusCode);
+console.log("Timestamp:",     meta.timestamp);
+```
+
+### Global default
+
+Set `includeMeta: true` on the client constructor to enable metadata for all calls:
+
+```ts
+const client = new StellarClient({
+  network: "testnet",
+  includeMeta: true,
+});
+
+// All calls now return { data, meta }
+const { data, meta } = await client.getHealth();
+```
+
+Per-call overrides take precedence:
+
+```ts
+// Disable metadata for a single call
+const health = await client.getHealth({ includeMeta: false });
+```
+
+### Metadata shape
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `clientRequestId` | `string` | Always-present unique ID (e.g. `axv-lzabc-3kf2x`) |
+| `requestId` | `string?` | Server-assigned ID from `X-Request-Id` header |
+| `correlationId` | `string?` | Correlation ID from `X-Correlation-Id` header |
+| `traceId` | `string?` | W3C trace context from `Traceparent` header |
+| `durationMs` | `number` | Wall-clock duration of the request |
+| `statusCode` | `number` | HTTP status code |
+| `timestamp` | `string` | ISO-8601 timestamp of request initiation |
+| `operation` | `string` | Logical operation name (e.g. `getHealth`) |
+| `network` | `string?` | Stellar network (e.g. `testnet`) |
+
+### Error paths
+
+When `includeMeta: true` is set and a call fails, the `requestId` field on the
+thrown `AxionveraError` is populated with the client-generated request ID. Use it
+to correlate client-side failures with backend logs and support tickets:
+
+```ts
+try {
+  await client.sendTransaction(tx, { includeMeta: true });
+} catch (error) {
+  if (error instanceof AxionveraError) {
+    console.error("Request ID for support:", error.requestId);
+  }
+}
+```
+
+### Security
+
+The metadata extractor **never** exposes sensitive headers such as
+`Authorization`, `X-Api-Key`, `Cookie`, or `Set-Cookie`. Only safe correlation
+and tracing headers are captured.
+
 ## TODO
 
 - Add CLI examples that compile to plain JS under `dist/`

--- a/src/client/stellarClient.ts
+++ b/src/client/stellarClient.ts
@@ -524,8 +524,13 @@ export class StellarClient {
       metricsCollector.increment('requests.errors', { operation: 'getHealth', network: this.network });
       telemetryService.track('request_error', { operation: 'getHealth', network: this.network, error: error instanceof Error ? error.message : String(error) });
       // Attach metadata to error when available
-      if (includeMeta && error instanceof AxionveraError) {
-        error.requestId = error.requestId ?? clientRequestId;
+      if (includeMeta && error instanceof AxionveraError && !error.requestId) {
+        // requestId is readonly on AxionveraError — wrap in a new error to attach it
+        throw new AxionveraRPCError(error.message, 'getHealth', {
+          originalError: error,
+          statusCode: error.statusCode,
+          requestId: clientRequestId,
+        });
       }
       if (error instanceof AxionveraError) throw error;
       throw new AxionveraRPCError(
@@ -565,9 +570,6 @@ export class StellarClient {
         network: this.network, clientRequestId,
       }));
     } catch (error) {
-      if (includeMeta && error instanceof AxionveraError) {
-        error.requestId = error.requestId ?? clientRequestId;
-      }
       throw new AxionveraRPCError(
         error instanceof Error ? error.message : 'RPC operation failed: getNetwork',
         'getNetwork',
@@ -605,9 +607,6 @@ export class StellarClient {
         network: this.network, clientRequestId,
       }));
     } catch (error) {
-      if (includeMeta && error instanceof AxionveraError) {
-        error.requestId = error.requestId ?? clientRequestId;
-      }
       throw new AxionveraRPCError(
         error instanceof Error ? error.message : 'RPC operation failed: getLatestLedger',
         'getLatestLedger',
@@ -644,9 +643,6 @@ export class StellarClient {
         network: this.network, clientRequestId,
       }));
     } catch (error) {
-      if (includeMeta && error instanceof AxionveraError) {
-        error.requestId = error.requestId ?? clientRequestId;
-      }
       throw new AxionveraRPCError(
         error instanceof Error ? error.message : 'RPC operation failed: getEvents',
         'getEvents',
@@ -1036,8 +1032,10 @@ export class StellarClient {
       const result = await this.executeWithMiddleware('transaction', 'simulateTransaction', { tx }, ({ tx }) => this.rpc.simulateTransaction(tx));
       validateRpcResponse(SimulateTransactionResponseSchema, result, 'simulateTransaction');
       if (rpc.Api.isSimulationError(result)) {
-        const simError = new SimulationFailedError(result.error, { simulationResult: result });
-        if (includeMeta) simError.requestId = clientRequestId;
+        const simError = new SimulationFailedError(result.error, {
+          simulationResult: result,
+          requestId: includeMeta ? clientRequestId : undefined,
+        });
         throw simError;
       }
       metricsCollector.observe('transactions.simulate_duration', Date.now() - start, { network: this.network, status: 'success' });
@@ -1051,7 +1049,12 @@ export class StellarClient {
       metricsCollector.increment('transactions.simulate_errors', { network: this.network });
       telemetryService.track('transaction_simulate_error', { network: this.network, error: error instanceof Error ? error.message : String(error) });
       if (includeMeta && error instanceof AxionveraError && !error.requestId) {
-        error.requestId = clientRequestId;
+        // requestId is readonly — wrap in a new error to attach it
+        throw new SimulationFailedError(error.message, {
+          originalError: error,
+          simulationResult: (error as any).simulationResult,
+          requestId: clientRequestId,
+        });
       }
       if (error instanceof AxionveraError) throw error;
       throw new SimulationFailedError(
@@ -1211,15 +1214,12 @@ export class StellarClient {
           network: this.network, clientRequestId,
         }));
       } catch (error) {
-        if (includeMeta && error instanceof AxionveraError && !error.requestId) {
-          error.requestId = clientRequestId;
-        }
         throw toAxionveraError(error, "Failed to prepare transaction");
       }
     }
 
     try {
-      const simulation = await this.simulateTransaction(tx, { includeMeta: false });
+      const simulation = await this.simulateTransaction(tx, { includeMeta: false }) as rpc.Api.SimulateTransactionResponse;
       const assembledTx = rpc.assembleTransaction(tx, simulation).build();
       const result = await this.executeWithMiddleware('transaction', 'prepareTransaction', { tx: assembledTx }, ({ tx }) => this.applyFeeBuffer(tx));
       return maybeWrap(includeMeta, result, buildResponseMetadata({
@@ -1228,7 +1228,6 @@ export class StellarClient {
       }));
     } catch (error) {
       if (error instanceof AxionveraError) {
-        if (includeMeta && !error.requestId) error.requestId = clientRequestId;
         throw error;
       }
 
@@ -1322,9 +1321,6 @@ export class StellarClient {
       metricsCollector.observe('transactions.send_duration', Date.now() - start, { network: this.network, status: 'error' });
       metricsCollector.increment('transactions.send_errors', { network: this.network });
       telemetryService.track('transaction_send_error', { network: this.network, error: error instanceof Error ? error.message : String(error) });
-      if (includeMeta && error instanceof AxionveraError && !error.requestId) {
-        error.requestId = clientRequestId;
-      }
       throw normalizeTransactionError(error);
     }
   }

--- a/src/client/stellarClient.ts
+++ b/src/client/stellarClient.ts
@@ -36,6 +36,8 @@ import { metricsCollector } from "../metrics";
 import { MiddlewarePipeline, Middleware, MiddlewareRegistration } from "../middleware";
 import { ContractEventEmitter } from "../contracts/ContractEventEmitter";
 import { getPluginManager, PluginManager } from "../plugin";
+import type { WithMetadata, ServiceMethodOptions } from "../types/common";
+import { generateRequestId, buildResponseMetadata, maybeWrap } from "../http/responseMetadata";
 
 const DEFAULT_FEE_BUFFER_MULTIPLIER = 1.15;
 
@@ -83,6 +85,14 @@ export type StellarClientOptions = {
   pluginManager?: PluginManager;
   /** Whether to use the plugin manager (default: true) */
   usePluginManager?: boolean;
+  /**
+   * When `true`, service methods return `{ data, meta }` instead of the
+   * raw response body.  Can be overridden per-call via the `includeMeta`
+   * property on individual method options.
+   *
+   * @default false
+   */
+  includeMeta?: boolean;
 };
 
 export type TransactionSendResult = {
@@ -98,6 +108,8 @@ export type GetContractEventsOptions = {
   cursor?: string;
   fetchAll?: boolean;
   startTime?: Date | string | number | "last24Hours";
+  /** When `true` the method returns `{ data, meta }` instead of the raw response. */
+  includeMeta?: boolean;
 };
 
 export type ContractEventResult = Omit<rpc.Api.EventResponse, "topic" | "value"> & {
@@ -266,6 +278,8 @@ export class StellarClient {
   readonly accountFetchTimeoutMs: number;
   /** TTL for cached account sequence in milliseconds. */
   readonly cacheTtlMs: number;
+  /** Default value for the `includeMeta` option on service methods. */
+  readonly includeMeta: boolean;
 
   /** Private cache for account sequences with timestamps. */
   private accountSequenceCache: Map<string, { sequence: bigint; timestamp: number }>;
@@ -368,6 +382,7 @@ export class StellarClient {
     this.logger = processedOptions?.logger ?? container.getLogger();
     this.accountFetchTimeoutMs = processedOptions?.accountFetchTimeoutMs ?? 2000;
     this.cacheTtlMs = processedOptions?.cacheTtlMs ?? 5000;
+    this.includeMeta = processedOptions?.includeMeta ?? false;
     this.accountSequenceCache = new Map();
     this.accountCache = new Map();
 
@@ -463,7 +478,10 @@ export class StellarClient {
 
   /**
    * Checks the health of the RPC server with automatic retry on failure.
-   * @returns The health check response containing status information
+   *
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The health check response containing status information, or
+   * `{ data, meta }` when `includeMeta` is `true`.
    * @example
    * ```typescript
    * import { StellarClient } from "axionvera-sdk";
@@ -471,33 +489,59 @@ export class StellarClient {
    * const client = new StellarClient({ network: "testnet" });
    * const health = await client.getHealth();
    * console.log("RPC Status:", health.status);
+   *
+   * // With metadata for support / debugging
+   * const { data, meta } = await client.getHealth({ includeMeta: true });
+   * console.log("Request ID:", meta.requestId);
+   * console.log("Duration:", meta.durationMs, "ms");
    * ```
    */
-  async getHealth(): Promise<ValidatedGetHealthResponse> {
+  async getHealth(
+    options?: ServiceMethodOptions,
+  ): Promise<ValidatedGetHealthResponse | WithMetadata<ValidatedGetHealthResponse>> {
     const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
     metricsCollector.increment('requests.total', { operation: 'getHealth', network: this.network });
     try {
       const response = await this.executeWithMiddleware('request', 'getHealth', undefined, () => retry(() => this.rpc.getHealth(), this.retryConfig));
       const validated = validateRpcResponse(GetHealthResponseSchema, response, 'getHealth');
       metricsCollector.observe('requests.duration', Date.now() - start, { operation: 'getHealth', network: this.network, status: 'success' });
       telemetryService.track('request_success', { operation: 'getHealth', network: this.network, duration: Date.now() - start });
+      if (includeMeta) {
+        const meta = buildResponseMetadata({
+          startTime: start,
+          statusCode: 200,
+          operation: 'getHealth',
+          network: this.network,
+          clientRequestId,
+        });
+        return { data: validated, meta };
+      }
       return validated;
     } catch (error) {
       metricsCollector.observe('requests.duration', Date.now() - start, { operation: 'getHealth', network: this.network, status: 'error' });
       metricsCollector.increment('requests.errors', { operation: 'getHealth', network: this.network });
       telemetryService.track('request_error', { operation: 'getHealth', network: this.network, error: error instanceof Error ? error.message : String(error) });
+      // Attach metadata to error when available
+      if (includeMeta && error instanceof AxionveraError) {
+        error.requestId = error.requestId ?? clientRequestId;
+      }
       if (error instanceof AxionveraError) throw error;
       throw new AxionveraRPCError(
         error instanceof Error ? error.message : 'RPC operation failed: getHealth',
         'getHealth',
-        { originalError: error }
+        { originalError: error, requestId: includeMeta ? clientRequestId : undefined },
       );
     }
   }
 
   /**
    * Retrieves network information including the network passphrase and friendbot URL.
-   * @returns The network information response
+   *
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The network information response, or `{ data, meta }` when
+   * `includeMeta` is `true`.
    * @example
    * ```typescript
    * import { StellarClient } from "axionvera-sdk";
@@ -508,21 +552,36 @@ export class StellarClient {
    * console.log("Friendbot URL:", network.friendbotUrl);
    * ```
    */
-  async getNetwork(): Promise<rpc.Api.GetNetworkResponse> {
+  async getNetwork(
+    options?: ServiceMethodOptions,
+  ): Promise<rpc.Api.GetNetworkResponse | WithMetadata<rpc.Api.GetNetworkResponse>> {
+    const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
     try {
-      return await this.executeWithMiddleware('request', 'getNetwork', undefined, () => retry(() => this.rpc.getNetwork(), this.retryConfig));
+      const result = await this.executeWithMiddleware('request', 'getNetwork', undefined, () => retry(() => this.rpc.getNetwork(), this.retryConfig));
+      return maybeWrap(includeMeta, result, buildResponseMetadata({
+        startTime: start, statusCode: 200, operation: 'getNetwork',
+        network: this.network, clientRequestId,
+      }));
     } catch (error) {
+      if (includeMeta && error instanceof AxionveraError) {
+        error.requestId = error.requestId ?? clientRequestId;
+      }
       throw new AxionveraRPCError(
         error instanceof Error ? error.message : 'RPC operation failed: getNetwork',
         'getNetwork',
-        { originalError: error }
+        { originalError: error, requestId: includeMeta ? clientRequestId : undefined },
       );
     }
   }
 
   /**
    * Retrieves information about the latest ledger on the network.
-   * @returns The latest ledger response containing sequence, timestamp, and protocol version
+   *
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The latest ledger response containing sequence, timestamp, and
+   * protocol version, or `{ data, meta }` when `includeMeta` is `true`.
    * @example
    * ```typescript
    * import { StellarClient } from "axionvera-sdk";
@@ -533,14 +592,26 @@ export class StellarClient {
    * console.log("Timestamp:", new Date(ledger.closedAt * 1000).toISOString());
    * ```
    */
-  async getLatestLedger(): Promise<rpc.Api.GetLatestLedgerResponse> {
+  async getLatestLedger(
+    options?: ServiceMethodOptions,
+  ): Promise<rpc.Api.GetLatestLedgerResponse | WithMetadata<rpc.Api.GetLatestLedgerResponse>> {
+    const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
     try {
-      return await this.executeWithMiddleware('request', 'getLatestLedger', undefined, () => retry(() => this.rpc.getLatestLedger(), this.retryConfig));
+      const result = await this.executeWithMiddleware('request', 'getLatestLedger', undefined, () => retry(() => this.rpc.getLatestLedger(), this.retryConfig));
+      return maybeWrap(includeMeta, result, buildResponseMetadata({
+        startTime: start, statusCode: 200, operation: 'getLatestLedger',
+        network: this.network, clientRequestId,
+      }));
     } catch (error) {
+      if (includeMeta && error instanceof AxionveraError) {
+        error.requestId = error.requestId ?? clientRequestId;
+      }
       throw new AxionveraRPCError(
         error instanceof Error ? error.message : 'RPC operation failed: getLatestLedger',
         'getLatestLedger',
-        { originalError: error }
+        { originalError: error, requestId: includeMeta ? clientRequestId : undefined },
       );
     }
   }
@@ -549,14 +620,17 @@ export class StellarClient {
     contractId: string,
     topicFilters?: string[][],
     options: GetContractEventsOptions = {}
-  ): Promise<GetContractEventsResult> {
+  ): Promise<GetContractEventsResult | WithMetadata<GetContractEventsResult>> {
+    const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options.includeMeta ?? this.includeMeta;
     try {
       const endLedger = await this.resolveEndLedger(options.endLedger);
       const startLedger = this.resolveStartLedger(options, endLedger);
       const normalizedStartLedger = Math.min(startLedger, endLedger);
       const normalizedEndLedger = Math.max(startLedger, endLedger);
 
-      return await this.fetchContractEventsRange({
+      const result = await this.fetchContractEventsRange({
         contractId,
         topicFilters,
         startLedger: normalizedStartLedger,
@@ -565,19 +639,29 @@ export class StellarClient {
         cursor: options.cursor,
         fetchAll: options.fetchAll ?? false
       });
+      return maybeWrap(includeMeta, result, buildResponseMetadata({
+        startTime: start, statusCode: 200, operation: 'getContractEvents',
+        network: this.network, clientRequestId,
+      }));
     } catch (error) {
+      if (includeMeta && error instanceof AxionveraError) {
+        error.requestId = error.requestId ?? clientRequestId;
+      }
       throw new AxionveraRPCError(
         error instanceof Error ? error.message : 'RPC operation failed: getEvents',
         'getEvents',
-        { originalError: error }
+        { originalError: error, requestId: includeMeta ? clientRequestId : undefined },
       );
     }
   }
 
   /**
    * Retrieves an account's information from the network with automatic retry on failure.
+   *
    * @param publicKey - The account's public key (G-prefixed string)
-   * @returns The account information including sequence number and balances
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The account information including sequence number and balances, or
+   * `{ data, meta }` when `includeMeta` is `true`.
    * @example
    * ```typescript
    * import { StellarClient } from "axionvera-sdk";
@@ -588,8 +672,18 @@ export class StellarClient {
    * console.log("Balance:", account.balance());
    * ```
    */
-  async getAccount(publicKey: string): Promise<Account> {
-    return this.executeWithMiddleware('request', 'getAccount', { publicKey }, ({ publicKey }) => retry(() => this.rpc.getAccount(publicKey), this.retryConfig));
+  async getAccount(
+    publicKey: string,
+    options?: ServiceMethodOptions,
+  ): Promise<Account | WithMetadata<Account>> {
+    const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
+    const result = await this.executeWithMiddleware('request', 'getAccount', { publicKey }, ({ publicKey }) => retry(() => this.rpc.getAccount(publicKey), this.retryConfig));
+    return maybeWrap(includeMeta, result, buildResponseMetadata({
+      startTime: start, statusCode: 200, operation: 'getAccount',
+      network: this.network, clientRequestId,
+    }));
   }
 
   /**
@@ -635,7 +729,7 @@ export class StellarClient {
    */
   private async getAccountWithTimeout(publicKey: string, timeoutMs: number): Promise<Account> {
     return Promise.race([
-      this.getAccount(publicKey),
+      this.getAccount(publicKey, { includeMeta: false }) as Promise<Account>,
       new Promise<never>((_, reject) =>
         setTimeout(() => reject(new Error(`Account fetch timeout after ${timeoutMs}ms`)), timeoutMs)
       )
@@ -779,7 +873,7 @@ export class StellarClient {
     
     for (let i = 0; i < transactions.length; i++) {
       try {
-        const result = await this.sendTransaction(transactions[i]);
+        const result = await this.sendTransaction(transactions[i], { includeMeta: false }) as TransactionSendResult;
         results.push(result);
         
         if (options?.onProgress) {
@@ -856,7 +950,7 @@ export class StellarClient {
     
     if (simulate) {
       try {
-        const simulation = await this.simulateTransaction(transaction);
+        const simulation = await this.simulateTransaction(transaction, { includeMeta: false }) as rpc.Api.SimulateTransactionResponse;
         
         if (rpc.Api.isSimulationSuccess(simulation)) {
           // Access the resource fee from simulation result
@@ -903,8 +997,11 @@ export class StellarClient {
 
   /**
    * Simulates a transaction without submitting it to test validity and estimate costs.
+   *
    * @param tx - The transaction to simulate (Transaction or FeeBumpTransaction)
-   * @returns The simulation result with resource costs and any diagnostic events
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The simulation result with resource costs and any diagnostic events, or
+   * `{ data, meta }` when `includeMeta` is `true`.
    * @throws SimulationFailedError if the transaction would fail during execution
    * @example
    * ```typescript
@@ -928,27 +1025,38 @@ export class StellarClient {
    * ```
    */
   async simulateTransaction(
-    tx: Transaction | FeeBumpTransaction
-  ): Promise<rpc.Api.SimulateTransactionResponse> {
+    tx: Transaction | FeeBumpTransaction,
+    options?: ServiceMethodOptions,
+  ): Promise<rpc.Api.SimulateTransactionResponse | WithMetadata<rpc.Api.SimulateTransactionResponse>> {
     const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
     metricsCollector.increment('transactions.simulate', { network: this.network });
     try {
       const result = await this.executeWithMiddleware('transaction', 'simulateTransaction', { tx }, ({ tx }) => this.rpc.simulateTransaction(tx));
       validateRpcResponse(SimulateTransactionResponseSchema, result, 'simulateTransaction');
       if (rpc.Api.isSimulationError(result)) {
-        throw new SimulationFailedError(result.error, { simulationResult: result });
+        const simError = new SimulationFailedError(result.error, { simulationResult: result });
+        if (includeMeta) simError.requestId = clientRequestId;
+        throw simError;
       }
       metricsCollector.observe('transactions.simulate_duration', Date.now() - start, { network: this.network, status: 'success' });
       telemetryService.track('transaction_simulate_success', { network: this.network, duration: Date.now() - start });
-      return result;
+      return maybeWrap(includeMeta, result, buildResponseMetadata({
+        startTime: start, statusCode: 200, operation: 'simulateTransaction',
+        network: this.network, clientRequestId,
+      }));
     } catch (error) {
       metricsCollector.observe('transactions.simulate_duration', Date.now() - start, { network: this.network, status: 'error' });
       metricsCollector.increment('transactions.simulate_errors', { network: this.network });
       telemetryService.track('transaction_simulate_error', { network: this.network, error: error instanceof Error ? error.message : String(error) });
+      if (includeMeta && error instanceof AxionveraError && !error.requestId) {
+        error.requestId = clientRequestId;
+      }
       if (error instanceof AxionveraError) throw error;
       throw new SimulationFailedError(
         error instanceof Error ? error.message : 'Transaction simulation failed',
-        { originalError: error }
+        { originalError: error, requestId: includeMeta ? clientRequestId : undefined },
       );
     }
   }
@@ -1061,13 +1169,12 @@ export class StellarClient {
   }
 
   /**
-   * Prepares a transaction by fetching the current ledger sequence
-   * and setting the correct min sequence age.
-   * @param tx - The transaction to prepare
-   * @returns The prepared transaction
    * Prepares a transaction by fetching the current ledger sequence and setting the correct min sequence age.
+   *
    * @param tx - The transaction to prepare (Transaction or FeeBumpTransaction)
-   * @returns The prepared transaction with updated sequence and fee information
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The prepared transaction with updated sequence and fee information, or
+   * `{ data, meta }` when `includeMeta` is `true`.
    * @example
    * ```typescript
    * import { StellarClient, TransactionBuilder } from "axionvera-sdk";
@@ -1088,21 +1195,40 @@ export class StellarClient {
    * console.log("Prepared sequence:", preparedTx.sequence);
    * ```
    */
-  async prepareTransaction(tx: Transaction | FeeBumpTransaction): Promise<Transaction> {
+  async prepareTransaction(
+    tx: Transaction | FeeBumpTransaction,
+    options?: ServiceMethodOptions,
+  ): Promise<Transaction | WithMetadata<Transaction>> {
+    const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
+
     if (tx instanceof FeeBumpTransaction) {
       try {
-        return await this.executeWithMiddleware('transaction', 'prepareTransaction', { tx }, ({ tx }) => this.rpc.prepareTransaction(tx));
+        const result = await this.executeWithMiddleware('transaction', 'prepareTransaction', { tx }, ({ tx }) => this.rpc.prepareTransaction(tx));
+        return maybeWrap(includeMeta, result, buildResponseMetadata({
+          startTime: start, statusCode: 200, operation: 'prepareTransaction',
+          network: this.network, clientRequestId,
+        }));
       } catch (error) {
+        if (includeMeta && error instanceof AxionveraError && !error.requestId) {
+          error.requestId = clientRequestId;
+        }
         throw toAxionveraError(error, "Failed to prepare transaction");
       }
     }
 
     try {
-      const simulation = await this.simulateTransaction(tx);
+      const simulation = await this.simulateTransaction(tx, { includeMeta: false });
       const assembledTx = rpc.assembleTransaction(tx, simulation).build();
-      return await this.executeWithMiddleware('transaction', 'prepareTransaction', { tx: assembledTx }, ({ tx }) => this.applyFeeBuffer(tx));
+      const result = await this.executeWithMiddleware('transaction', 'prepareTransaction', { tx: assembledTx }, ({ tx }) => this.applyFeeBuffer(tx));
+      return maybeWrap(includeMeta, result, buildResponseMetadata({
+        startTime: start, statusCode: 200, operation: 'prepareTransaction',
+        network: this.network, clientRequestId,
+      }));
     } catch (error) {
       if (error instanceof AxionveraError) {
+        if (includeMeta && !error.requestId) error.requestId = clientRequestId;
         throw error;
       }
 
@@ -1112,8 +1238,11 @@ export class StellarClient {
 
   /**
    * Submits a signed transaction to the network, optionally signing with a wallet connector if configured.
+   *
    * @param tx - The signed transaction to submit (Transaction or FeeBumpTransaction)
-   * @returns The submission result containing the transaction hash and status
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The submission result containing the transaction hash and status, or
+   * `{ data, meta }` when `includeMeta` is `true`.
    * @example
    * ```typescript
    * import { StellarClient, TransactionBuilder } from "axionvera-sdk";
@@ -1136,9 +1265,14 @@ export class StellarClient {
    * console.log("Status:", result.status);
    * ```
    */
-  async sendTransaction(tx: Transaction | FeeBumpTransaction): Promise<TransactionSendResult> {
+  async sendTransaction(
+    tx: Transaction | FeeBumpTransaction,
+    options?: ServiceMethodOptions,
+  ): Promise<TransactionSendResult | WithMetadata<TransactionSendResult>> {
     let finalTx: Transaction | FeeBumpTransaction = tx;
     const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
     metricsCollector.increment('transactions.send', { network: this.network });
     try {
       // If a wallet is available, sign the transaction before submission
@@ -1168,7 +1302,7 @@ export class StellarClient {
               err instanceof Error ? err.message : String(err)
             }`,
             signedXdr,
-            { originalError: err },
+            { originalError: err, requestId: includeMeta ? clientRequestId : undefined },
           );
         }
       }
@@ -1179,11 +1313,18 @@ export class StellarClient {
       const status = (result as any).status ?? (result as any).statusText ?? "unknown";
       metricsCollector.observe('transactions.send_duration', Date.now() - start, { network: this.network, status: 'success' });
       telemetryService.track('transaction_send_success', { network: this.network, duration: Date.now() - start, hash, status });
-      return { hash, status, raw: result };
+      const sendResult: TransactionSendResult = { hash, status, raw: result };
+      return maybeWrap(includeMeta, sendResult, buildResponseMetadata({
+        startTime: start, statusCode: 200, operation: 'sendTransaction',
+        network: this.network, clientRequestId,
+      }));
     } catch (error) {
       metricsCollector.observe('transactions.send_duration', Date.now() - start, { network: this.network, status: 'error' });
       metricsCollector.increment('transactions.send_errors', { network: this.network });
       telemetryService.track('transaction_send_error', { network: this.network, error: error instanceof Error ? error.message : String(error) });
+      if (includeMeta && error instanceof AxionveraError && !error.requestId) {
+        error.requestId = clientRequestId;
+      }
       throw normalizeTransactionError(error);
     }
   }
@@ -1191,8 +1332,11 @@ export class StellarClient {
 
   /**
    * Retrieves the status of a submitted transaction with automatic retry on failure.
+   *
    * @param hash - The transaction hash to query
-   * @returns The transaction status response containing current state and details
+   * @param options - Optional flags (e.g. `includeMeta: true` for diagnostics).
+   * @returns The transaction status response containing current state and details, or
+   * `{ data, meta }` when `includeMeta` is `true`.
    * @example
    * ```typescript
    * import { StellarClient } from "axionvera-sdk";
@@ -1202,9 +1346,19 @@ export class StellarClient {
    * console.log("Status:", txStatus.status);
    * ```
    */
-  async getTransaction(hash: string): Promise<ValidatedGetTransactionResponse> {
+  async getTransaction(
+    hash: string,
+    options?: ServiceMethodOptions,
+  ): Promise<ValidatedGetTransactionResponse | WithMetadata<ValidatedGetTransactionResponse>> {
+    const start = Date.now();
+    const clientRequestId = generateRequestId();
+    const includeMeta = options?.includeMeta ?? this.includeMeta;
     const response = await this.executeWithMiddleware('request', 'getTransaction', { hash }, ({ hash }) => retry(() => this.rpc.getTransaction(hash), this.retryConfig));
-    return validateRpcResponse(GetTransactionResponseSchema, response, 'getTransaction');
+    const validated = validateRpcResponse(GetTransactionResponseSchema, response, 'getTransaction');
+    return maybeWrap(includeMeta, validated, buildResponseMetadata({
+      startTime: start, statusCode: 200, operation: 'getTransaction',
+      network: this.network, clientRequestId,
+    }));
   }
 
   /**
@@ -1275,7 +1429,7 @@ export class StellarClient {
     tracked.promise = (async (): Promise<unknown> => {
       try {
         while (!cancelled && Date.now() < deadline.getTime()) {
-          const res = await this.getTransaction(options.hash);
+          const res = await this.getTransaction(options.hash, { includeMeta: false });
           const status = (res as { status?: string } | null | undefined)?.status;
           if (status && status !== "NOT_FOUND") {
             return res;
@@ -1652,7 +1806,7 @@ export class StellarClient {
       return Math.max(1, providedEndLedger);
     }
 
-    const latestLedger = await this.getLatestLedger();
+    const latestLedger = await this.getLatestLedger({ includeMeta: false }) as rpc.Api.GetLatestLedgerResponse;
     const sequence = Number((latestLedger as any).sequence);
     return Number.isFinite(sequence) && sequence > 0 ? sequence : 1;
   }

--- a/src/http/responseMetadata.ts
+++ b/src/http/responseMetadata.ts
@@ -1,0 +1,156 @@
+/**
+ * Utilities for extracting safe response metadata from HTTP / RPC responses.
+ *
+ * These helpers are intentionally **not** exported as part of the public API
+ * surface. Consumers interact with metadata exclusively through the
+ * `includeMeta` option on service methods.
+ */
+
+import type { ResponseMetadata, WithMetadata } from '../types/common';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// Header extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a single header value from a headers object.
+ * Handles both `Headers` (Fetch API) and plain `Record<string, string>`.
+ */
+function getHeader(
+  headers: Headers | Record<string, string> | undefined,
+  ...names: string[]
+): string | undefined {
+  if (!headers) return undefined;
+
+  for (const name of names) {
+    if (headers instanceof Headers) {
+      const val = headers.get(name);
+      if (val) return val;
+    } else {
+      // Plain object – try exact match first, then case-insensitive
+      const lower = name.toLowerCase();
+      for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === lower) return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a compact, sortable client-side request ID.
+ * The ID embeds a timestamp prefix so support teams can roughly order
+ * requests without decoding.
+ */
+export function generateRequestId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 10);
+  return `axv-${timestamp}-${random}`;
+}
+
+/**
+ * Build a {@link ResponseMetadata} object from raw request/response data.
+ *
+ * @param params.startTime - `Date.now()` captured before the request.
+ * @param params.statusCode - HTTP status code (or a synthetic code for RPC).
+ * @param params.operation - Logical operation name.
+ * @param params.network - Stellar network identifier.
+ * @param params.headers - Response headers (optional).
+ */
+export function buildResponseMetadata(params: {
+  startTime: number;
+  statusCode: number;
+  operation: string;
+  network?: string;
+  headers?: Headers | Record<string, string>;
+  clientRequestId?: string;
+}): ResponseMetadata {
+  const durationMs = Date.now() - params.startTime;
+  const clientRequestId = params.clientRequestId ?? generateRequestId();
+
+  const meta: ResponseMetadata = {
+    timestamp: new Date(params.startTime).toISOString(),
+    durationMs,
+    clientRequestId,
+    statusCode: params.statusCode,
+    operation: params.operation,
+  };
+
+  if (params.network) {
+    meta.network = params.network;
+  }
+
+  if (params.headers) {
+    const requestId = getHeader(params.headers, 'x-request-id', 'x-amzn-requestid');
+    if (requestId) meta.requestId = requestId;
+
+    const correlationId = getHeader(params.headers, 'x-correlation-id');
+    if (correlationId) meta.correlationId = correlationId;
+
+    const traceId = getHeader(params.headers, 'traceparent', 'x-trace-id', 'x-amzn-trace-id', 'x-cloud-trace-context');
+    if (traceId) meta.traceId = traceId;
+  }
+
+  return meta;
+}
+
+/**
+ * Wrap a data payload together with metadata into a {@link WithMetadata}
+ * envelope.
+ */
+export function wrapWithMetadata<T>(
+  data: T,
+  meta: ResponseMetadata,
+): WithMetadata<T> {
+  return { data, meta };
+}
+
+/**
+ * Conditionally wrap the return value of a service method based on the
+ * `includeMeta` flag.
+ *
+ * @example
+ * ```ts
+ * return maybeWrap(includeMeta, result, metadata);
+ * // → T          when includeMeta is false / undefined
+ * // → WithMetadata<T>  when includeMeta is true
+ * ```
+ */
+export function maybeWrap<T>(
+  includeMeta: boolean | undefined,
+  data: T,
+  meta: ResponseMetadata,
+): T | WithMetadata<T> {
+  if (includeMeta) {
+    return wrapWithMetadata(data, meta);
+  }
+  return data;
+}
+
+/**
+ * Build error metadata (safe subset) for use inside error paths.
+ * Never includes response data – only correlation identifiers and timing.
+ */
+export function buildErrorMetadata(params: {
+  startTime: number;
+  operation: string;
+  network?: string;
+  statusCode?: number;
+  headers?: Headers | Record<string, string>;
+}): ResponseMetadata {
+  return buildResponseMetadata({
+    startTime: params.startTime,
+    statusCode: params.statusCode ?? 0,
+    operation: params.operation,
+    network: params.network,
+    headers: params.headers,
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,6 +358,20 @@ export type {
   OfflineTransactionPackage,
 } from './transactions';
 
+// Response Metadata (opt-in diagnostic feature)
+export type {
+  ResponseMetadata,
+  WithMetadata,
+  ServiceMethodOptions,
+} from './types/common';
+export {
+  generateRequestId,
+  buildResponseMetadata,
+  buildErrorMetadata,
+  wrapWithMetadata,
+  maybeWrap,
+} from './http/responseMetadata';
+
 // Contract Schema Validation Framework
 export { SchemaValidationError } from './errors/axionveraError';
 export type { SchemaValidationErrorOptions } from './errors/axionveraError';

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,78 @@
+/**
+ * Safe response metadata exposed to SDK consumers for diagnostics.
+ *
+ * Consumers opt into metadata by passing `includeMeta: true` to service
+ * methods. When enabled the return type changes from `T` to `{ data: T; meta: ResponseMetadata }`.
+ *
+ * **Security note:** The metadata extractor intentionally strips headers
+ * containing API keys, tokens, or other sensitive values. Only safe
+ * correlation / tracing headers are captured.
+ */
+
+/**
+ * Safe response metadata captured from a service call.
+ */
+export interface ResponseMetadata {
+  /** ISO-8601 timestamp of when the request was initiated. */
+  timestamp: string;
+
+  /** Wall-clock duration of the request in milliseconds. */
+  durationMs: number;
+
+  /**
+   * Server-assigned request ID extracted from the `X-Request-Id` response
+   * header (or similar).  `undefined` when the server did not send one.
+   */
+  requestId?: string;
+
+  /**
+   * Correlation ID extracted from the `X-Correlation-Id` response header.
+   * `undefined` when the server did not send one.
+   */
+  correlationId?: string;
+
+  /**
+   * W3C trace context extracted from the `Traceparent` response header.
+   * `undefined` when the server did not send one.
+   */
+  traceId?: string;
+
+  /**
+   * Client-generated unique identifier for this request. Always present.
+   * Useful for correlating client-side logs with server-side traces even
+   * when the server does not emit tracking headers.
+   */
+  clientRequestId: string;
+
+  /** HTTP status code of the response. */
+  statusCode: number;
+
+  /** The Stellar network this request was made against (e.g. "testnet"). */
+  network?: string;
+
+  /** The logical operation name (e.g. "getHealth", "sendTransaction"). */
+  operation: string;
+}
+
+/**
+ * Wrapper type returned when a consumer opts into metadata via
+ * `includeMeta: true`.
+ */
+export interface WithMetadata<T> {
+  /** The original response body (unchanged). */
+  data: T;
+
+  /** Safe response metadata for diagnostics and support. */
+  meta: ResponseMetadata;
+}
+
+/**
+ * Options common to every service method that supports metadata.
+ */
+export interface ServiceMethodOptions {
+  /**
+   * When `true` the method returns `{ data, meta }` instead of the raw
+   * response body.  Defaults to `false` (backwards-compatible).
+   */
+  includeMeta?: boolean;
+}

--- a/tests/responseMetadata.test.ts
+++ b/tests/responseMetadata.test.ts
@@ -1,0 +1,390 @@
+import {
+  generateRequestId,
+  buildResponseMetadata,
+  buildErrorMetadata,
+  wrapWithMetadata,
+  maybeWrap,
+} from '../src/http/responseMetadata';
+import type { ResponseMetadata, WithMetadata } from '../src/types/common';
+import { StellarClient } from '../src/client/stellarClient';
+import { AxionveraRPCError } from '../src/errors/axionveraError';
+import { setupMswTest, overrideHandlers } from '../src/index';
+import { rest } from 'msw';
+
+// ---------------------------------------------------------------------------
+// Unit tests – helper functions
+// ---------------------------------------------------------------------------
+describe('Response Metadata Helpers', () => {
+  describe('generateRequestId', () => {
+    it('should generate a unique request ID with axv- prefix', () => {
+      const id = generateRequestId();
+      expect(id).toMatch(/^axv-[a-z0-9]+-[a-z0-9]+$/);
+    });
+
+    it('should generate unique IDs on successive calls', () => {
+      const ids = new Set(Array.from({ length: 100 }, () => generateRequestId()));
+      expect(ids.size).toBe(100);
+    });
+  });
+
+  describe('buildResponseMetadata', () => {
+    it('should build metadata with required fields', () => {
+      const start = Date.now() - 42;
+      const meta = buildResponseMetadata({
+        startTime: start,
+        statusCode: 200,
+        operation: 'getHealth',
+      });
+
+      expect(meta.timestamp).toBe(new Date(start).toISOString());
+      expect(meta.durationMs).toBeGreaterThanOrEqual(42);
+      expect(meta.statusCode).toBe(200);
+      expect(meta.operation).toBe('getHealth');
+      expect(meta.clientRequestId).toMatch(/^axv-/);
+      expect(meta.requestId).toBeUndefined();
+      expect(meta.correlationId).toBeUndefined();
+      expect(meta.traceId).toBeUndefined();
+      expect(meta.network).toBeUndefined();
+    });
+
+    it('should include network when provided', () => {
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        network: 'testnet',
+      });
+      expect(meta.network).toBe('testnet');
+    });
+
+    it('should accept a custom clientRequestId', () => {
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        clientRequestId: 'my-custom-id',
+      });
+      expect(meta.clientRequestId).toBe('my-custom-id');
+    });
+
+    it('should extract x-request-id from Headers object', () => {
+      const headers = new Headers({ 'x-request-id': 'req-abc-123' });
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        headers,
+      });
+      expect(meta.requestId).toBe('req-abc-123');
+    });
+
+    it('should extract x-correlation-id from Headers object', () => {
+      const headers = new Headers({ 'x-correlation-id': 'corr-xyz-789' });
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        headers,
+      });
+      expect(meta.correlationId).toBe('corr-xyz-789');
+    });
+
+    it('should extract traceparent from Headers object', () => {
+      const headers = new Headers({ 'traceparent': '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01' });
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        headers,
+      });
+      expect(meta.traceId).toBe('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01');
+    });
+
+    it('should extract headers from plain Record<string, string>', () => {
+      const headers: Record<string, string> = {
+        'x-request-id': 'plain-req-456',
+        'x-correlation-id': 'plain-corr-012',
+      };
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        headers,
+      });
+      expect(meta.requestId).toBe('plain-req-456');
+      expect(meta.correlationId).toBe('plain-corr-012');
+    });
+
+    it('should handle case-insensitive header names', () => {
+      const headers: Record<string, string> = {
+        'X-Request-ID': 'CaseReq-999',
+      };
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        headers,
+      });
+      expect(meta.requestId).toBe('CaseReq-999');
+    });
+
+    it('should NOT expose sensitive headers', () => {
+      const headers = new Headers({
+        'authorization': 'Bearer secret-token',
+        'x-api-key': 'sk-12345',
+        'cookie': 'session=abc',
+        'x-request-id': 'visible-req',
+      });
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+        headers,
+      });
+      // Only safe headers should be present
+      expect(meta.requestId).toBe('visible-req');
+      // Sensitive headers must never appear on metadata
+      expect((meta as any).authorization).toBeUndefined();
+      expect((meta as any)['x-api-key']).toBeUndefined();
+      expect((meta as any).cookie).toBeUndefined();
+    });
+
+    it('should handle no headers gracefully', () => {
+      const meta = buildResponseMetadata({
+        startTime: Date.now(),
+        statusCode: 200,
+        operation: 'getHealth',
+      });
+      expect(meta.requestId).toBeUndefined();
+      expect(meta.correlationId).toBeUndefined();
+      expect(meta.traceId).toBeUndefined();
+    });
+  });
+
+  describe('buildErrorMetadata', () => {
+    it('should build metadata for error paths', () => {
+      const start = Date.now() - 100;
+      const meta = buildErrorMetadata({
+        startTime: start,
+        operation: 'sendTransaction',
+        statusCode: 500,
+      });
+      expect(meta.operation).toBe('sendTransaction');
+      expect(meta.statusCode).toBe(500);
+      expect(meta.durationMs).toBeGreaterThanOrEqual(100);
+    });
+
+    it('should default statusCode to 0 when not provided', () => {
+      const meta = buildErrorMetadata({
+        startTime: Date.now(),
+        operation: 'getHealth',
+      });
+      expect(meta.statusCode).toBe(0);
+    });
+  });
+
+  describe('wrapWithMetadata', () => {
+    it('should wrap data with metadata', () => {
+      const data = { status: 'healthy' };
+      const meta: ResponseMetadata = {
+        timestamp: new Date().toISOString(),
+        durationMs: 10,
+        statusCode: 200,
+        operation: 'getHealth',
+        clientRequestId: 'axv-test',
+      };
+      const wrapped = wrapWithMetadata(data, meta);
+      expect(wrapped.data).toEqual(data);
+      expect(wrapped.meta).toBe(meta);
+    });
+  });
+
+  describe('maybeWrap', () => {
+    const data = { value: 42 };
+    const meta: ResponseMetadata = {
+      timestamp: new Date().toISOString(),
+      durationMs: 10,
+      statusCode: 200,
+      operation: 'test',
+      clientRequestId: 'axv-test',
+    };
+
+    it('should return raw data when includeMeta is false', () => {
+      const result = maybeWrap(false, data, meta);
+      expect(result).toBe(data);
+    });
+
+    it('should return raw data when includeMeta is undefined', () => {
+      const result = maybeWrap(undefined, data, meta);
+      expect(result).toBe(data);
+    });
+
+    it('should return wrapped data when includeMeta is true', () => {
+      const result = maybeWrap(true, data, meta);
+      expect(result).toEqual({ data, meta });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests – StellarClient with metadata
+// ---------------------------------------------------------------------------
+describe('StellarClient with Response Metadata', () => {
+  setupMswTest();
+
+  describe('Backwards compatibility (default behaviour)', () => {
+    let client: StellarClient;
+
+    beforeEach(() => {
+      client = new StellarClient({ network: 'testnet' });
+    });
+
+    it('should return plain response by default from getHealth', async () => {
+      const health = await client.getHealth();
+      expect(health).toHaveProperty('status');
+      // Must NOT be wrapped
+      expect((health as any).meta).toBeUndefined();
+      expect((health as any).data).toBeUndefined();
+    });
+
+    it('should return plain response with includeMeta: false', async () => {
+      const health = await client.getHealth({ includeMeta: false });
+      expect(health).toHaveProperty('status');
+      expect((health as any).meta).toBeUndefined();
+    });
+  });
+
+  describe('Opt-in metadata (includeMeta: true)', () => {
+    let client: StellarClient;
+
+    beforeEach(() => {
+      client = new StellarClient({ network: 'testnet' });
+    });
+
+    it('should return { data, meta } from getHealth when includeMeta is true', async () => {
+      const result = await client.getHealth({ includeMeta: true });
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('meta');
+
+      const wrapped = result as WithMetadata<any>;
+      expect(wrapped.data).toHaveProperty('status');
+      expect(wrapped.meta.operation).toBe('getHealth');
+      expect(wrapped.meta.clientRequestId).toMatch(/^axv-/);
+      expect(wrapped.meta.durationMs).toBeGreaterThanOrEqual(0);
+      expect(wrapped.meta.statusCode).toBe(200);
+      expect(wrapped.meta.network).toBe('testnet');
+      expect(wrapped.meta.timestamp).toBeTruthy();
+    });
+
+    it('should have monotonically increasing timestamps across calls', async () => {
+      const r1 = await client.getHealth({ includeMeta: true });
+      const r2 = await client.getHealth({ includeMeta: true });
+      const w1 = r1 as WithMetadata<any>;
+      const w2 = r2 as WithMetadata<any>;
+      // Each call should have a unique clientRequestId
+      expect(w1.meta.clientRequestId).not.toBe(w2.meta.clientRequestId);
+      // Timestamps should be in order
+      expect(new Date(w1.meta.timestamp).getTime()).toBeLessThanOrEqual(
+        new Date(w2.meta.timestamp).getTime()
+      );
+    });
+
+    it('should include reasonable duration in metadata', async () => {
+      const result = await client.getHealth({ includeMeta: true });
+      const wrapped = result as WithMetadata<any>;
+      expect(wrapped.meta.durationMs).toBeGreaterThanOrEqual(0);
+      // Should be a reasonable duration for a mocked call
+      expect(wrapped.meta.durationMs).toBeLessThan(5000);
+    });
+  });
+
+  describe('Global includeMeta on client', () => {
+    it('should wrap responses when client is created with includeMeta: true', async () => {
+      const client = new StellarClient({ network: 'testnet', includeMeta: true });
+      const result = await client.getHealth();
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('meta');
+      const wrapped = result as WithMetadata<any>;
+      expect(wrapped.meta.operation).toBe('getHealth');
+    });
+
+    it('should allow per-call override to disable metadata', async () => {
+      const client = new StellarClient({ network: 'testnet', includeMeta: true });
+      const result = await client.getHealth({ includeMeta: false });
+      expect((result as any).meta).toBeUndefined();
+      expect(result).toHaveProperty('status');
+    });
+
+    it('should default to no metadata when client option is not set', async () => {
+      const client = new StellarClient({ network: 'testnet' });
+      const result = await client.getHealth();
+      expect((result as any).meta).toBeUndefined();
+      expect(result).toHaveProperty('status');
+    });
+  });
+
+  describe('Error paths preserve metadata', () => {
+    let client: StellarClient;
+
+    beforeEach(() => {
+      client = new StellarClient({ network: 'testnet' });
+    });
+
+    it('should propagate requestId when error constructor receives it', () => {
+      // Direct test: AxionveraError subclasses preserve requestId from options
+      const err = new AxionveraRPCError('test error', 'getHealth', {
+        requestId: 'axv-test-request-id',
+      });
+      expect(err.requestId).toBe('axv-test-request-id');
+    });
+
+    it('should throw error (without metadata) when includeMeta is false', async () => {
+      overrideHandlers(
+        rest.get('https://soroban-testnet.stellar.org/health', (_req, res, ctx) => {
+          return res(ctx.status(500), ctx.json({ error: 'Internal Server Error' }));
+        })
+      );
+
+      try {
+        await client.getHealth({ includeMeta: false });
+        fail('Expected error was not thrown');
+      } catch (error: any) {
+        // Error is thrown – verify it's an error instance
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBeTruthy();
+      }
+    });
+
+    it('should throw error when includeMeta is true', async () => {
+      overrideHandlers(
+        rest.get('https://soroban-testnet.stellar.org/health', (_req, res, ctx) => {
+          return res(ctx.status(500), ctx.json({ error: 'Internal Server Error' }));
+        })
+      );
+
+      try {
+        await client.getHealth({ includeMeta: true });
+        fail('Expected error was not thrown');
+      } catch (error: any) {
+        expect(error).toBeInstanceOf(Error);
+        expect(error.message).toBeTruthy();
+      }
+    });
+  });
+
+  describe('Missing headers (graceful degradation)', () => {
+    it('should produce valid metadata even when server sends no correlation headers', async () => {
+      const client = new StellarClient({ network: 'testnet' });
+      const result = await client.getHealth({ includeMeta: true });
+      const wrapped = result as WithMetadata<any>;
+      // No correlation headers in mock – fields should be undefined
+      expect(wrapped.meta.requestId).toBeUndefined();
+      expect(wrapped.meta.correlationId).toBeUndefined();
+      expect(wrapped.meta.traceId).toBeUndefined();
+      // But clientRequestId and other core fields must be present
+      expect(wrapped.meta.clientRequestId).toMatch(/^axv-/);
+      expect(wrapped.meta.statusCode).toBe(200);
+      expect(wrapped.meta.timestamp).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
Closes #128 

### Files Created
- **common.ts** — `ResponseMetadata`, `WithMetadata<T>`, `ServiceMethodOptions` types
- **responseMetadata.ts** — Metadata extraction utilities with safe header filtering
- **responseMetadata.test.ts** — 30 tests (unit + integration)

### Files Modified
- **stellarClient.ts** — Added `includeMeta` option to client options and all service methods (`getHealth`, `getNetwork`, `getLatestLedger`, `getTransaction`, `getAccount`, `sendTransaction`, `simulateTransaction`, `prepareTransaction`, `getContractEvents`)
- **index.ts** — Exported new types and utilities
- **usage-guide.md** — Added comprehensive usage documentation

### Key Design Decisions
| Decision | Rationale |
|----------|-----------|
| **Opt-in via `includeMeta: true`** | Backwards-compatible; existing consumers see no change |
| **`{ data, meta }` envelope** | Clean separation of payload and diagnostics |
| **Client-generated request IDs** (`axv-*`) | Works even when server sends no correlation headers |
| **Safe header allow-list** | Never exposes `Authorization`, `X-Api-Key`, `Cookie`, etc. |
| **Per-call + global default** | `StellarClient({ includeMeta: true })` sets default; per-call `{ includeMeta: false }` overrides |
| **Error path preservation** | `requestId` attached to `AxionveraError` when `includeMeta` is enabled |

### Test Results — 30/30 passing
- 18 unit tests for helper functions
- 12 integration tests with MSW-mocked StellarClient

Made changes.