### PR TITLE
Feature/response metadata

### DIFF
--- a/packages/core/src/client/stellarClient.ts
+++ b/packages/core/src/client/stellarClient.ts
@@ -11,24 +11,12 @@ import {
   Transaction,
   TransactionBuilder,
   xdr
-    Account,
-Address,
-Contract,
-FeeBumpTransaction,
-Keypair,
-nativeToScVal,
-scValToNative,
-rpc,
-SorobanDataBuilder,
-Transaction,
-TransactionBuilder,
-xdr
 } from "@stellar/stellar-sdk";
 
 import {
-AxionveraNetwork,
-getNetworkPassphrase,
-resolveNetworkConfig
+  AxionveraNetwork,
+  getNetworkPassphrase,
+  resolveNetworkConfig
 } from "../utils/networkConfig";
 import { ConcurrencyConfig, DEFAULT_CONCURRENCY_CONFIG, createConcurrencyControlledClient } from "../utils/concurrencyQueue";
 import { RetryConfig, createHttpClientWithRetry, retry } from "../utils/httpInterceptor";
@@ -41,31 +29,15 @@ import {
   ValidatedGetHealthResponse,
   ValidatedGetTransactionResponse,
 } from "../utils/rpcSchemas";
-import {
-NetworkError,
-toAxionveraError,
-InsecureNetworkError,
-AxionveraError,
-TransactionTimeoutError,
-ValidationError
-} from "../errors/axionveraError";
 import { LogLevel, Logger } from "../utils/logger";
 import { WebSocketManager, EventFilter, SorobanEvent, WebSocketConfig } from "./websocket";
 import { CloudWatchConfig } from "../utils/logging/cloudwatch";
 import {
-validateRpcResponse,
-GetHealthResponseSchema,
-SimulateTransactionResponseSchema,
-GetTransactionResponseSchema,
-ValidatedGetHealthResponse,
-ValidatedGetTransactionResponse,
-} from "../utils/rpcSchemas";
-import {
-FetchTransactionHistoryOptions,
-TransactionHistoryResult,
-parseTransaction,
-sortByTimestamp,
-filterByActionType
+  FetchTransactionHistoryOptions,
+  TransactionHistoryResult,
+  parseTransaction,
+  sortByTimestamp,
+  filterByActionType
 } from "../utils/transactionHistory";
 import { parseSorobanEvent, ParsedSorobanEvent } from "../utils/sorobanEventParser";
 import {

--- a/packages/core/src/errors/axionveraError.ts
+++ b/packages/core/src/errors/axionveraError.ts
@@ -60,6 +60,7 @@ export class StellarRpcResponseError extends AxionveraError {}
 export class StellarRpcTimeoutError extends AxionveraError {}
 
 export class InsecureNetworkError extends AxionveraError {}
+export class NetworkMismatchError extends AxionveraError {}
 export class TransactionTimeoutError extends StellarRpcTimeoutError {}
 
 export class WalletNotInstalledError extends AxionveraError {}

--- a/packages/core/src/http/responseMetadata.ts
+++ b/packages/core/src/http/responseMetadata.ts
@@ -1,0 +1,68 @@
+import type { ResponseMetadata, WithMetadata } from '../types/common';
+
+export function generateRequestId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 10);
+  return `axv-${timestamp}-${random}`;
+}
+
+function getHeader(
+  headers: Headers | Record<string, string> | undefined,
+  ...names: string[]
+): string | undefined {
+  if (!headers) return undefined;
+  for (const name of names) {
+    if (headers instanceof Headers) {
+      const val = headers.get(name);
+      if (val) return val;
+    } else {
+      const lower = name.toLowerCase();
+      for (const [key, value] of Object.entries(headers)) {
+        if (key.toLowerCase() === lower) return value;
+      }
+    }
+  }
+  return undefined;
+}
+
+export function buildResponseMetadata(params: {
+  startTime: number;
+  statusCode: number;
+  operation: string;
+  network?: string;
+  headers?: Headers | Record<string, string>;
+  clientRequestId?: string;
+}): ResponseMetadata {
+  const durationMs = Date.now() - params.startTime;
+  const clientRequestId = params.clientRequestId ?? generateRequestId();
+
+  const meta: ResponseMetadata = {
+    timestamp: new Date(params.startTime).toISOString(),
+    durationMs,
+    clientRequestId,
+    statusCode: params.statusCode,
+    operation: params.operation,
+  };
+
+  if (params.network) meta.network = params.network;
+
+  if (params.headers) {
+    const requestId = getHeader(params.headers, 'x-request-id', 'x-amzn-requestid');
+    if (requestId) meta.requestId = requestId;
+    const correlationId = getHeader(params.headers, 'x-correlation-id');
+    if (correlationId) meta.correlationId = correlationId;
+    const traceId = getHeader(params.headers, 'traceparent', 'x-trace-id', 'x-amzn-trace-id', 'x-cloud-trace-context');
+    if (traceId) meta.traceId = traceId;
+  }
+
+  return meta;
+}
+
+export function maybeWrap<T>(
+  includeMeta: boolean | undefined,
+  data: T,
+  meta: ResponseMetadata,
+): T | WithMetadata<T> {
+  if (includeMeta) return { data, meta };
+  return data;
+}

--- a/packages/core/src/test/msw/setup.ts
+++ b/packages/core/src/test/msw/setup.ts
@@ -1,0 +1,2 @@
+// Re-export MSW test utilities
+export { setupMswTest, overrideHandlers } from './server';

--- a/packages/core/src/types/common.ts
+++ b/packages/core/src/types/common.ts
@@ -1,0 +1,46 @@
+/**
+ * Safe response metadata exposed to SDK consumers for diagnostics.
+ *
+ * Consumers opt into metadata by passing `includeMeta: true` to service
+ * methods. When enabled the return type changes from `T` to `{ data: T; meta: ResponseMetadata }`.
+ *
+ * **Security note:** The metadata extractor intentionally strips headers
+ * containing API keys, tokens, or other sensitive values. Only safe
+ * correlation / tracing headers are captured.
+ */
+
+/**
+ * Safe response metadata captured from a service call.
+ */
+export interface ResponseMetadata {
+  /** ISO-8601 timestamp of when the request was initiated. */
+  timestamp: string;
+  /** Wall-clock duration of the request in milliseconds. */
+  durationMs: number;
+  /** Server-assigned request ID extracted from response headers. */
+  requestId?: string;
+  /** Correlation ID extracted from the `X-Correlation-Id` response header. */
+  correlationId?: string;
+  /** W3C trace context extracted from the `Traceparent` response header. */
+  traceId?: string;
+  /** Client-generated unique identifier for this request. Always present. */
+  clientRequestId: string;
+  /** HTTP status code of the response. */
+  statusCode: number;
+  /** The Stellar network this request was made against. */
+  network?: string;
+  /** The logical operation name. */
+  operation: string;
+}
+
+/** Wrapper type returned when a consumer opts into metadata. */
+export interface WithMetadata<T> {
+  data: T;
+  meta: ResponseMetadata;
+}
+
+/** Options common to every service method that supports metadata. */
+export interface ServiceMethodOptions {
+  /** When true, returns `{ data, meta }` instead of raw response. */
+  includeMeta?: boolean;
+}


### PR DESCRIPTION
Closes #128 

CJS and ESM builds succeed now. Let me commit and push:


- Add missing ContractEventResult type export
- Remove duplicate BaseContractConfig export
- Remove duplicate VaultConfig/VaultInfo/DepositParams/WithdrawParams exports
- Remove non-existent ErrorCodes/classifyError/isRetryable/shouldRetry exports"


| Issue | Fix |
|-------|-----|
| `ContractEventResult` not exported | Added type alias `ContractEventResult = ParsedSorobanEvent` |
| Duplicate `BaseContractConfig` export | Removed the duplicate line |
| Duplicate `VaultConfig`/`VaultInfo`/`DepositParams`/`WithdrawParams` | Removed duplicates from `VaultContract` path |
| Missing `ErrorCodes`/`classifyError`/`isRetryable`/`shouldRetry` | Removed broken exports (implementations don't exist) |

**Build status:** CJS ✅ &nbsp; ESM ✅ &nbsp; (DTS has pre-existing unused-var errors in Vault.ts, not from our changes)

Made changes.